### PR TITLE
fix: include Spanner gRPC test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <protobuf.version>3.11.3</protobuf.version>
     <threeten.version>1.4.1</threeten.version>
     <google.api-common.version>1.8.1</google.api-common.version>
-    <spanner.version>1.47.0</spanner.version>
+    <spanner.version>1.49.2</spanner.version>
     <hamcrest.version>2.2</hamcrest.version>
     <error-prone.version>2.3.4</error-prone.version>
     <google.auth.version>0.20.0</google.auth.version>
@@ -242,6 +242,24 @@
       <artifactId>google-cloud-spanner</artifactId>
       <version>${spanner.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-spanner-v1</artifactId>
+      <version>${spanner.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-spanner-admin-instance-v1</artifactId>
+      <version>${spanner.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-spanner-admin-database-v1</artifactId>
+      <version>${spanner.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-            <ignoredUnusedDeclaredDependencies>com.google.api:gax-grpc</ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependencies>
+              <ignoredDependency>com.google.api:gax-grpc</ignoredDependency>
+              <ignoredDependency>com.google.api.grpc:grpc-google-cloud-spanner-v1</ignoredDependency>
+              <ignoredDependency>com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1</ignoredDependency>
+              <ignoredDependency>com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1</ignoredDependency>
+            </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
The JDBC driver did not include the Spanner gRPC classes that are needed for testing.

Fixes #59 