### PR TITLE
fix: fix deprecation warnings in JDBC (test) files

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -169,6 +169,7 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
   }
 
   @Override
+  @Deprecated
   public void setUnicodeStream(int parameterIndex, InputStream value, int length)
       throws SQLException {
     checkClosed();

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcResultSet.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcResultSet.java
@@ -215,6 +215,7 @@ class JdbcResultSet extends AbstractJdbcResultSet {
   }
 
   @Override
+  @Deprecated
   public InputStream getUnicodeStream(int columnIndex) throws SQLException {
     checkClosedAndValidRow();
     return getInputStream(getString(columnIndex), StandardCharsets.UTF_16LE);
@@ -314,6 +315,7 @@ class JdbcResultSet extends AbstractJdbcResultSet {
   }
 
   @Override
+  @Deprecated
   public InputStream getUnicodeStream(String columnLabel) throws SQLException {
     checkClosedAndValidRow();
     return getInputStream(getString(columnLabel), StandardCharsets.UTF_16LE);
@@ -406,12 +408,14 @@ class JdbcResultSet extends AbstractJdbcResultSet {
   }
 
   @Override
+  @Deprecated
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
     checkClosedAndValidRow();
     return getBigDecimal(columnIndex, true, scale);
   }
 
   @Override
+  @Deprecated
   public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
     checkClosedAndValidRow();
     return getBigDecimal(spanner.getColumnIndex(columnLabel) + 1, true, scale);

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
@@ -16,11 +16,8 @@
 
 package com.google.cloud.spanner.jdbc;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,15 +45,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class JdbcConnectionTest {
-  @Rule public final ExpectedException exception = ExpectedException.none();
   private static final com.google.cloud.spanner.ResultSet SELECT1_RESULTSET =
       ResultSets.forRows(
           Type.struct(StructField.of("", Type.int64())),
@@ -76,14 +70,14 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     when(options.isAutocommit()).thenReturn(true);
     try (Connection connection = createConnection(options)) {
-      assertThat(connection.getAutoCommit(), is(true));
+      assertThat(connection.getAutoCommit()).isTrue();
       connection.setAutoCommit(false);
-      assertThat(connection.getAutoCommit(), is(false));
+      assertThat(connection.getAutoCommit()).isFalse();
       // execute a query that will start a transaction
       connection.createStatement().executeQuery(AbstractConnectionImplTest.SELECT);
       // setting autocommit will automatically commit the transaction
       connection.setAutoCommit(true);
-      assertThat(connection.getAutoCommit(), is(true));
+      assertThat(connection.getAutoCommit()).isTrue();
     }
   }
 
@@ -93,14 +87,17 @@ public class JdbcConnectionTest {
     when(options.isAutocommit()).thenReturn(true);
     when(options.isReadOnly()).thenReturn(true);
     try (Connection connection = createConnection(options)) {
-      assertThat(connection.isReadOnly(), is(true));
+      assertThat(connection.isReadOnly()).isTrue();
       connection.setReadOnly(false);
-      assertThat(connection.isReadOnly(), is(false));
+      assertThat(connection.isReadOnly()).isFalse();
       // start a transaction
       connection.createStatement().execute("begin transaction");
       // setting readonly should no longer be allowed
-      exception.expect(JdbcExceptionMatcher.matchCode(Code.FAILED_PRECONDITION));
+      //      exception.expect(JdbcExceptionMatcher.matchCode(Code.FAILED_PRECONDITION));
       connection.setReadOnly(true);
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(JdbcExceptionMatcher.matchCode(Code.FAILED_PRECONDITION).matches(e)).isTrue();
     }
   }
 
@@ -109,17 +106,17 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
       // verify that there is no transaction started
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(false));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isFalse();
       // start a transaction
       connection.createStatement().execute(AbstractConnectionImplTest.SELECT);
       // verify that we did start a transaction
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(true));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isTrue();
       // do a commit
       connection.commit();
       // verify that there is no transaction started anymore
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(false));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isFalse();
       // verify that there is a commit timestamp
-      assertThat(connection.getSpannerConnection().getCommitTimestamp(), is(notNullValue()));
+      assertThat(connection.getSpannerConnection().getCommitTimestamp()).isNotNull();
     }
   }
 
@@ -128,20 +125,20 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
       // verify that there is no transaction started
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(false));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isFalse();
       // start a transaction
       connection.createStatement().execute(AbstractConnectionImplTest.SELECT);
       // verify that we did start a transaction
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(true));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isTrue();
       // do a rollback
       connection.rollback();
       // verify that there is no transaction started anymore
-      assertThat(connection.getSpannerConnection().isTransactionStarted(), is(false));
+      assertThat(connection.getSpannerConnection().isTransactionStarted()).isFalse();
       // verify that there is no commit timestamp
       try (ResultSet rs =
           connection.createStatement().executeQuery("show variable commit_timestamp")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getTimestamp("COMMIT_TIMESTAMP"), is(nullValue()));
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getTimestamp("COMMIT_TIMESTAMP")).isNull();
       }
     }
   }
@@ -310,18 +307,17 @@ public class JdbcConnectionTest {
         valid = true;
       }
     }
-    assertThat(
-        "Method did not throw exception on closed connection: " + method.getName(),
-        valid,
-        is(true));
+    assertWithMessage("Method did not throw exception on closed connection: " + method.getName())
+        .that(valid)
+        .isTrue();
   }
 
   @Test
   public void testTransactionIsolation() throws SQLException {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(
-          connection.getTransactionIsolation(), is(equalTo(Connection.TRANSACTION_SERIALIZABLE)));
+      assertThat(connection.getTransactionIsolation())
+          .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
       // assert that setting it to this value is ok.
       connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
       // assert that setting it to something else is not ok.
@@ -347,7 +343,7 @@ public class JdbcConnectionTest {
                     && ((JdbcSqlException) e).getCode() == Code.UNIMPLEMENTED);
           }
         }
-        assertThat(exception, is(true));
+        assertThat(exception).isTrue();
       }
     }
   }
@@ -356,7 +352,7 @@ public class JdbcConnectionTest {
   public void testHoldability() throws SQLException {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(connection.getHoldability(), is(equalTo(ResultSet.CLOSE_CURSORS_AT_COMMIT)));
+      assertThat(connection.getHoldability()).isEqualTo(ResultSet.CLOSE_CURSORS_AT_COMMIT);
       // assert that setting it to this value is ok.
       connection.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
       // assert that setting it to something else is not ok.
@@ -376,7 +372,7 @@ public class JdbcConnectionTest {
                     && ((JdbcSqlException) e).getCode() == Code.UNIMPLEMENTED);
           }
         }
-        assertThat(exception, is(true));
+        assertThat(exception).isTrue();
       }
     }
   }
@@ -385,24 +381,24 @@ public class JdbcConnectionTest {
   public void testWarnings() throws SQLException {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(connection.getWarnings(), is(nullValue()));
+      assertThat((Object) connection.getWarnings()).isNull();
 
       // Push one warning and get it twice.
       connection.pushWarning(new SQLWarning("test"));
-      assertThat(connection.getWarnings().getMessage(), is(equalTo("test")));
-      assertThat(connection.getWarnings().getMessage(), is(equalTo("test")));
+      assertThat(connection.getWarnings().getMessage()).isEqualTo("test");
+      assertThat(connection.getWarnings().getMessage()).isEqualTo("test");
 
       // Clear warnings and push two warnings and get them both.
       connection.clearWarnings();
       connection.pushWarning(new SQLWarning("test 1"));
       connection.pushWarning(new SQLWarning("test 2"));
-      assertThat(connection.getWarnings().getMessage(), is(equalTo("test 1")));
-      assertThat(connection.getWarnings().getMessage(), is(equalTo("test 1")));
-      assertThat(connection.getWarnings().getNextWarning().getMessage(), is(equalTo("test 2")));
+      assertThat(connection.getWarnings().getMessage()).isEqualTo("test 1");
+      assertThat(connection.getWarnings().getMessage()).isEqualTo("test 1");
+      assertThat(connection.getWarnings().getNextWarning().getMessage()).isEqualTo("test 2");
 
       // Clear warnings.
       connection.clearWarnings();
-      assertThat(connection.getWarnings(), is(nullValue()));
+      assertThat((Object) connection.getWarnings()).isNull();
     }
   }
 
@@ -410,23 +406,21 @@ public class JdbcConnectionTest {
   public void testSetClientInfo() throws SQLException {
     ConnectionOptions options = mock(ConnectionOptions.class);
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(connection.getWarnings(), is(nullValue()));
+      assertThat((Object) connection.getWarnings()).isNull();
       connection.setClientInfo("test", "foo");
-      assertThat(connection.getWarnings(), is(notNullValue()));
-      assertThat(
-          connection.getWarnings().getMessage(),
-          is(equalTo(AbstractJdbcConnection.CLIENT_INFO_NOT_SUPPORTED)));
+      assertThat((Object) connection.getWarnings()).isNotNull();
+      assertThat(connection.getWarnings().getMessage())
+          .isEqualTo(AbstractJdbcConnection.CLIENT_INFO_NOT_SUPPORTED);
 
       connection.clearWarnings();
-      assertThat(connection.getWarnings(), is(nullValue()));
+      assertThat((Object) connection.getWarnings()).isNull();
 
       Properties props = new Properties();
       props.setProperty("test", "foo");
       connection.setClientInfo(props);
-      assertThat(connection.getWarnings(), is(notNullValue()));
-      assertThat(
-          connection.getWarnings().getMessage(),
-          is(equalTo(AbstractJdbcConnection.CLIENT_INFO_NOT_SUPPORTED)));
+      assertThat((Object) connection.getWarnings()).isNotNull();
+      assertThat(connection.getWarnings().getMessage())
+          .isEqualTo(AbstractJdbcConnection.CLIENT_INFO_NOT_SUPPORTED);
     }
   }
 
@@ -442,13 +436,13 @@ public class JdbcConnectionTest {
     // Verify that an opened connection that returns a result set is valid.
     try (JdbcConnection connection = new JdbcConnection("url", options)) {
       when(spannerConnection.executeQuery(statement)).thenReturn(SELECT1_RESULTSET);
-      assertThat(connection.isValid(1), is(true));
+      assertThat(connection.isValid(1)).isTrue();
       try {
         // Invalid timeout value.
         connection.isValid(-1);
         fail("missing expected exception");
       } catch (JdbcSqlExceptionImpl e) {
-        assertThat(e.getCode(), is(equalTo(Code.INVALID_ARGUMENT)));
+        assertThat(e.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
       }
 
       // Now let the query return an error. isValid should now return false.
@@ -456,7 +450,7 @@ public class JdbcConnectionTest {
           .thenThrow(
               SpannerExceptionFactory.newSpannerException(
                   ErrorCode.ABORTED, "the current transaction has been aborted"));
-      assertThat(connection.isValid(1), is(false));
+      assertThat(connection.isValid(1)).isFalse();
     }
   }
 
@@ -464,7 +458,7 @@ public class JdbcConnectionTest {
   public void testIsValidOnClosedConnection() throws SQLException {
     Connection connection = createConnection(mock(ConnectionOptions.class));
     connection.close();
-    assertThat(connection.isValid(1), is(false));
+    assertThat(connection.isValid(1)).isFalse();
   }
 
   @Test
@@ -483,8 +477,8 @@ public class JdbcConnectionTest {
           {
             java.sql.Statement statement =
                 connection.createStatement(resultSetType, resultSetConcurrency);
-            assertThat(statement.getResultSetType(), is(equalTo(resultSetType)));
-            assertThat(statement.getResultSetConcurrency(), is(equalTo(resultSetConcurrency)));
+            assertThat(statement.getResultSetType()).isEqualTo(resultSetType);
+            assertThat(statement.getResultSetConcurrency()).isEqualTo(resultSetConcurrency);
           } else {
             assertCreateStatementFails(connection, resultSetType, resultSetConcurrency);
           }
@@ -499,9 +493,9 @@ public class JdbcConnectionTest {
               java.sql.Statement statement =
                   connection.createStatement(
                       resultSetType, resultSetConcurrency, resultSetHoldability);
-              assertThat(statement.getResultSetType(), is(equalTo(resultSetType)));
-              assertThat(statement.getResultSetConcurrency(), is(equalTo(resultSetConcurrency)));
-              assertThat(statement.getResultSetHoldability(), is(equalTo(resultSetHoldability)));
+              assertThat(statement.getResultSetType()).isEqualTo(resultSetType);
+              assertThat(statement.getResultSetConcurrency()).isEqualTo(resultSetConcurrency);
+              assertThat(statement.getResultSetHoldability()).isEqualTo(resultSetHoldability);
             } else {
               assertCreateStatementFails(
                   connection, resultSetType, resultSetConcurrency, resultSetHoldability);
@@ -557,8 +551,8 @@ public class JdbcConnectionTest {
           {
             PreparedStatement ps =
                 connection.prepareStatement("SELECT 1", resultSetType, resultSetConcurrency);
-            assertThat(ps.getResultSetType(), is(equalTo(resultSetType)));
-            assertThat(ps.getResultSetConcurrency(), is(equalTo(resultSetConcurrency)));
+            assertThat(ps.getResultSetType()).isEqualTo(resultSetType);
+            assertThat(ps.getResultSetConcurrency()).isEqualTo(resultSetConcurrency);
           } else {
             assertPrepareStatementFails(connection, resultSetType, resultSetConcurrency);
           }
@@ -573,9 +567,9 @@ public class JdbcConnectionTest {
               PreparedStatement ps =
                   connection.prepareStatement(
                       "SELECT 1", resultSetType, resultSetConcurrency, resultSetHoldability);
-              assertThat(ps.getResultSetType(), is(equalTo(resultSetType)));
-              assertThat(ps.getResultSetConcurrency(), is(equalTo(resultSetConcurrency)));
-              assertThat(ps.getResultSetHoldability(), is(equalTo(resultSetHoldability)));
+              assertThat(ps.getResultSetType()).isEqualTo(resultSetType);
+              assertThat(ps.getResultSetConcurrency()).isEqualTo(resultSetConcurrency);
+              assertThat(ps.getResultSetHoldability()).isEqualTo(resultSetHoldability);
             } else {
               assertPrepareStatementFails(
                   connection, resultSetType, resultSetConcurrency, resultSetHoldability);
@@ -623,7 +617,7 @@ public class JdbcConnectionTest {
       PreparedStatement statement =
           connection.prepareStatement(sql, java.sql.Statement.NO_GENERATED_KEYS);
       ResultSet rs = statement.getGeneratedKeys();
-      assertThat(rs.next(), is(false));
+      assertThat(rs.next()).isFalse();
       try {
         statement = connection.prepareStatement(sql, java.sql.Statement.RETURN_GENERATED_KEYS);
         fail("missing expected SQLFeatureNotSupportedException");
@@ -638,7 +632,7 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     when(options.getDatabaseName()).thenReturn("test");
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(connection.getCatalog(), is(equalTo("test")));
+      assertThat(connection.getCatalog()).isEqualTo("test");
       // This should be allowed.
       connection.setCatalog("");
       try {
@@ -646,7 +640,7 @@ public class JdbcConnectionTest {
         connection.setCatalog("other");
         fail("missing expected exception");
       } catch (JdbcSqlExceptionImpl e) {
-        assertThat(e.getCode(), is(equalTo(Code.INVALID_ARGUMENT)));
+        assertThat(e.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
       }
     }
   }
@@ -654,7 +648,7 @@ public class JdbcConnectionTest {
   @Test
   public void testSchema() throws SQLException {
     try (JdbcConnection connection = createConnection(mock(ConnectionOptions.class))) {
-      assertThat(connection.getSchema(), is(equalTo("")));
+      assertThat(connection.getSchema()).isEqualTo("");
       // This should be allowed.
       connection.setSchema("");
       try {
@@ -662,7 +656,7 @@ public class JdbcConnectionTest {
         connection.setSchema("other");
         fail("missing expected exception");
       } catch (JdbcSqlExceptionImpl e) {
-        assertThat(e.getCode(), is(equalTo(Code.INVALID_ARGUMENT)));
+        assertThat(e.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
       }
     }
   }

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
@@ -93,7 +93,6 @@ public class JdbcConnectionTest {
       // start a transaction
       connection.createStatement().execute("begin transaction");
       // setting readonly should no longer be allowed
-      //      exception.expect(JdbcExceptionMatcher.matchCode(Code.FAILED_PRECONDITION));
       connection.setReadOnly(true);
       fail("missing expected exception");
     } catch (SQLException e) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcGrpcErrorTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcGrpcErrorTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.spanner.jdbc;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import com.google.cloud.spanner.MockSpannerServiceImpl;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
@@ -43,9 +46,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -84,7 +85,6 @@ public class JdbcGrpcErrorTest {
   private static Server server;
   private static InetSocketAddress address;
 
-  @Rule public ExpectedException expected = ExpectedException.none();
   // FAILED_PRECONDITION is chosen as the test error code as it should never be retryable.
   private final Exception serverException =
       Status.FAILED_PRECONDITION.withDescription("test exception").asRuntimeException();
@@ -143,87 +143,100 @@ public class JdbcGrpcErrorTest {
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void autocommitBeginTransaction() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitBeginTransaction() {
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void autocommitBeginPDMLTransaction() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitBeginPDMLTransaction() {
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().execute("SET AUTOCOMMIT_DML_MODE='PARTITIONED_NON_ATOMIC'");
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void transactionalBeginTransaction() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void transactionalBeginTransaction() {
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void readOnlyBeginTransaction() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void readOnlyBeginTransaction() {
     mockSpanner.setBeginTransactionExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.setReadOnly(true);
       connection.createStatement().executeQuery(SELECT1.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void autocommitExecuteSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitExecuteSql() {
     mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void autocommitPDMLExecuteSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitPDMLExecuteSql() {
     mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().execute("SET AUTOCOMMIT_DML_MODE='PARTITIONED_NON_ATOMIC'");
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void transactionalExecuteSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void transactionalExecuteSql() {
     mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
   public void autocommitExecuteBatchDml() throws SQLException {
-    expected.expect(testExceptionMatcher);
     mockSpanner.setExecuteBatchDmlExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
@@ -231,13 +244,15 @@ public class JdbcGrpcErrorTest {
         statement.addBatch(UPDATE_STATEMENT.getSql());
         statement.addBatch(UPDATE_STATEMENT.getSql());
         statement.executeBatch();
+        fail("missing expected exception");
+      } catch (SQLException e) {
+        assertThat(testExceptionMatcher.matches(e)).isTrue();
       }
     }
   }
 
   @Test
   public void transactionalExecuteBatchDml() throws SQLException {
-    expected.expect(testExceptionMatcher);
     mockSpanner.setExecuteBatchDmlExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
@@ -246,40 +261,51 @@ public class JdbcGrpcErrorTest {
         statement.addBatch(UPDATE_STATEMENT.getSql());
         statement.addBatch(UPDATE_STATEMENT.getSql());
         statement.executeBatch();
+        fail("missing expected exception");
+      } catch (SQLException e) {
+        assertThat(testExceptionMatcher.matches(e)).isTrue();
       }
     }
   }
 
   @Test
-  public void autocommitCommit() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitCommit() {
     mockSpanner.setCommitExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void transactionalCommit() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void transactionalCommit() {
     mockSpanner.setCommitExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
       connection.commit();
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void autocommitRollback() throws SQLException {
+  public void autocommitRollback() {
     // The JDBC driver should throw the exception of the SQL statement and ignore any errors from
     // the rollback() method.
-    expected.expect(
-        SpannerJdbcExceptionMatcher.matchCodeAndMessage(
-            JdbcSqlExceptionImpl.class, Code.NOT_FOUND, "Unknown table name"));
     mockSpanner.setRollbackExecutionTime(SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeUpdate(INVALID_UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(
+              SpannerJdbcExceptionMatcher.matchCodeAndMessage(
+                      JdbcSqlExceptionImpl.class, Code.NOT_FOUND, "Unknown table name")
+                  .matches(e))
+          .isTrue();
     }
   }
 
@@ -296,74 +322,86 @@ public class JdbcGrpcErrorTest {
   }
 
   @Test
-  public void autocommitExecuteStreamingSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitExecuteStreamingSql() {
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeQuery(SELECT1.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void transactionalExecuteStreamingSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void transactionalExecuteStreamingSql() {
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.createStatement().executeQuery(SELECT1.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Test
-  public void readOnlyExecuteStreamingSql() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void readOnlyExecuteStreamingSql() {
     mockSpanner.setExecuteStreamingSqlExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.setReadOnly(true);
       connection.createStatement().executeQuery(SELECT1.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void autocommitCreateSession() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void autocommitCreateSession() {
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void transactionalCreateSession() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void transactionalCreateSession() {
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 
   @Ignore(
       "This can only be guaranteed with MinSessions=0. Re-enable when MinSessions is configurable for JDBC.")
   @Test
-  public void readOnlyCreateSession() throws SQLException {
-    expected.expect(testExceptionMatcher);
+  public void readOnlyCreateSession() {
     mockSpanner.setBatchCreateSessionsExecutionTime(
         SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.setAutoCommit(false);
       connection.setReadOnly(true);
       connection.createStatement().executeQuery(SELECT1.getSql());
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(testExceptionMatcher.matches(e)).isTrue();
     }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
@@ -50,16 +50,12 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.TimeZone;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class JdbcPreparedStatementTest {
-  @Rule public final ExpectedException thrown = ExpectedException.none();
-
   private String generateSqlWithParameters(int numberOfParams) {
     StringBuilder sql = new StringBuilder("INSERT INTO FOO (");
     boolean first = true;
@@ -100,6 +96,7 @@ public class JdbcPreparedStatementTest {
     return connection;
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testParameters() throws SQLException, MalformedURLException {
     final int numberOfParams = 48;

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcReadOnlyTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcReadOnlyTest.java
@@ -29,10 +29,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -41,8 +39,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ITJdbcReadOnlyTest extends ITAbstractJdbcTest {
   private static final long TEST_ROWS_COUNT = 1000L;
-
-  @Rule public ExpectedException exception = ExpectedException.none();
 
   @Override
   protected void appendConnectionUri(StringBuilder url) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcReadWriteAutocommitTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcReadWriteAutocommitTest.java
@@ -27,10 +27,8 @@ import com.google.cloud.spanner.jdbc.ITAbstractJdbcTest;
 import com.google.cloud.spanner.jdbc.JdbcSqlScriptVerifier;
 import com.google.cloud.spanner.jdbc.SqlScriptVerifier;
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.MethodSorters;
@@ -39,8 +37,6 @@ import org.junit.runners.MethodSorters;
 @RunWith(JUnit4.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ITJdbcReadWriteAutocommitTest extends ITAbstractJdbcTest {
-
-  @Rule public ExpectedException exception = ExpectedException.none();
 
   @Override
   protected void appendConnectionUri(StringBuilder uri) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcSimpleStatementsTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcSimpleStatementsTest.java
@@ -69,7 +69,7 @@ public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
           ps.setInt(1, i);
           try (ResultSet rs = ps.executeQuery()) {
             assertThat(rs.next()).isTrue();
-            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.getInt(1)).isEqualTo(i);
             assertThat(rs.next()).isFalse();
           }
         }

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcSimpleStatementsTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcSimpleStatementsTest.java
@@ -16,9 +16,8 @@
 
 package com.google.cloud.spanner.jdbc.it;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.cloud.spanner.IntegrationTest;
 import com.google.cloud.spanner.jdbc.ITAbstractJdbcTest;
@@ -27,10 +26,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -38,15 +35,13 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @Category(IntegrationTest.class)
 public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
-  @Rule public final ExpectedException expected = ExpectedException.none();
-
   @Test
   public void testSelect1() throws SQLException {
     try (Connection connection = createConnection()) {
       try (ResultSet rs = connection.createStatement().executeQuery("select 1")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(equalTo(1)));
-        assertThat(rs.next(), is(false));
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getInt(1)).isEqualTo(1);
+        assertThat(rs.next()).isFalse();
       }
     }
   }
@@ -56,9 +51,9 @@ public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
     try (Connection connection = createConnection()) {
       try (PreparedStatement ps = connection.prepareStatement("select 1")) {
         try (ResultSet rs = ps.executeQuery()) {
-          assertThat(rs.next(), is(true));
-          assertThat(rs.getInt(1), is(equalTo(1)));
-          assertThat(rs.next(), is(false));
+          assertThat(rs.next()).isTrue();
+          assertThat(rs.getInt(1)).isEqualTo(1);
+          assertThat(rs.next()).isFalse();
         }
       }
     }
@@ -73,9 +68,9 @@ public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
         for (int i = 1; i <= 3; i++) {
           ps.setInt(1, i);
           try (ResultSet rs = ps.executeQuery()) {
-            assertThat(rs.next(), is(true));
-            assertThat(rs.getInt(1), is(equalTo(i)));
-            assertThat(rs.next(), is(false));
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt(1)).isEqualTo(1);
+            assertThat(rs.next()).isFalse();
           }
         }
       }
@@ -92,17 +87,17 @@ public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
         statement.addBatch(
             "CREATE TABLE FOO2 (ID INT64 NOT NULL, NAME STRING(100)) PRIMARY KEY (ID)");
         int[] updateCounts = statement.executeBatch();
-        assertThat(
-            updateCounts,
-            is(equalTo(new int[] {Statement.SUCCESS_NO_INFO, Statement.SUCCESS_NO_INFO})));
+        assertThat(updateCounts)
+            .asList()
+            .containsExactly(Statement.SUCCESS_NO_INFO, Statement.SUCCESS_NO_INFO);
       }
       try (ResultSet rs =
           connection
               .createStatement()
               .executeQuery(
                   "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME LIKE 'FOO%'")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getLong(1), is(equalTo(2L)));
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getLong(1)).isEqualTo(2L);
       }
     }
     // Execute a batch of DDL statements that contains a statement that will fail.
@@ -121,35 +116,37 @@ public class ITJdbcSimpleStatementsTest extends ITAbstractJdbcTest {
       } catch (SQLException e) {
         gotExpectedException = true;
       }
-      assertThat(gotExpectedException, is(true));
+      assertThat(gotExpectedException).isTrue();
       // The table should have been created, the index should not.
       try (ResultSet rs =
           connection
               .createStatement()
               .executeQuery(
                   "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='' AND TABLE_NAME LIKE 'FOO%'")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getLong(1), is(equalTo(3L)));
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getLong(1)).isEqualTo(3L);
       }
       try (ResultSet rs =
           connection
               .createStatement()
               .executeQuery(
                   "SELECT COUNT(*) FROM INFORMATION_SCHEMA.INDEXES WHERE TABLE_SCHEMA='' AND INDEX_NAME='IDX_FOO1_UNIQUE'")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getLong(1), is(equalTo(0L)));
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getLong(1)).isEqualTo(0L);
       }
     }
   }
 
   @Test
-  public void testAddBatchWhenAlreadyInBatch() throws SQLException {
-    expected.expect(SQLException.class);
-    expected.expectMessage(
-        "Calling addBatch() is not allowed when a DML or DDL batch has been started on the connection.");
+  public void testAddBatchWhenAlreadyInBatch() {
     try (Connection connection = createConnection()) {
       connection.createStatement().execute("START BATCH DML");
       connection.createStatement().addBatch("INSERT INTO Singers (SingerId) VALUES (-1)");
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat(e.getMessage())
+          .contains(
+              "Calling addBatch() is not allowed when a DML or DDL batch has been started on the connection.");
     }
   }
 }


### PR DESCRIPTION
Fixes deprecation warnings and moves to `com.google.common.truth.Truth` assertions for JDBC files.