### PR TITLE
test: run integration tests against the emulator

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.sh
+++ b/.github/workflows/integration-tests-against-emulator.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License..
+
+# Fail on any error
+set -e
+
+# Display commands being run
+set -x
+
+export SPANNER_EMULATOR_HOST=localhost:9010
+export GOOGLE_CLOUD_PROJECT=emulator-test-project
+echo "Running the Cloud Spanner emulator: $SPANNER_EMULATOR_HOST";
+
+# Download the emulator
+EMULATOR_VERSION=0.8.0
+wget https://storage.googleapis.com/cloud-spanner-emulator/releases/${EMULATOR_VERSION}/cloud-spanner-emulator_linux_amd64-${EMULATOR_VERSION}.tar.gz
+tar zxvf cloud-spanner-emulator_linux_amd64-${EMULATOR_VERSION}.tar.gz
+chmod u+x emulator_main
+
+# Start the emulator
+./emulator_main --host_port $SPANNER_EMULATOR_HOST &
+
+EMULATOR_PID=$!
+
+# Stop the emulator & clean the environment variable
+trap "kill -2 $EMULATOR_PID; unset SPANNER_EMULATOR_HOST; unset GOOGLE_CLOUD_PROJECT; echo \"Cleanup the emulator\";" EXIT
+
+mvn -B -Dspanner.testenv.instance="" \
+  -Penable-integration-tests \
+  -DtrimStackTrace=false \
+  -Dclirr.skip=true \
+  -Denforcer.skip=true \
+  -fae \
+  verify

--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+name: integration-tests-against-emulator
+jobs:
+  units:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - run: java -version
+    - run: .kokoro/build.sh
+    - run: sh .github/workflows/integration-tests-against-emulator.sh
+      env:
+        JOB_TYPE: test


### PR DESCRIPTION
I don't think this works yet. The test script is getting stuck with a warning:

```
WARNING: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/.
```
