### PR TITLE
fix: return empty catalog name

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -291,7 +291,7 @@ class JdbcConnection extends AbstractJdbcConnection {
   @Override
   public String getCatalog() throws SQLException {
     checkClosed();
-    return getConnectionOptions().getDatabaseName();
+    return "";
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
@@ -634,7 +634,9 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     when(options.getDatabaseName()).thenReturn("test");
     try (JdbcConnection connection = createConnection(options)) {
-      assertThat(connection.getCatalog()).isEqualTo("test");
+      // The connection should always return the empty string as the current catalog, as no other
+      // catalogs exist in the INFORMATION_SCHEMA.
+      assertThat(connection.getCatalog()).isEqualTo("");
       // This should be allowed.
       connection.setCatalog("");
       try {


### PR DESCRIPTION
The JDBC connection would return the current database name as the current catalog name, but that catalog name would not be returned in the ResultSet returned by getCatalogs(). This discrepancy causes some tools to ignore or misinterpret the catalog and schema structure of a Cloud Spanner database. Specifically, it breaks the autocomplete feature of DBeaver.

See also https://github.com/dbeaver/dbeaver/pull/9127