### PR TITLE
chore(deps): update dependency com.google.cloud:libraries-bom to v8.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>8.0.0</version>
+        <version>8.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcGrpcErrorTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcGrpcErrorTest.java
@@ -214,7 +214,8 @@ public class JdbcGrpcErrorTest {
 
   @Test
   public void autocommitPDMLExecuteSql() {
-    mockSpanner.setExecuteSqlExecutionTime(SimulatedExecutionTime.ofException(serverException));
+    mockSpanner.setExecuteStreamingSqlExecutionTime(
+        SimulatedExecutionTime.ofException(serverException));
     try (java.sql.Connection connection = createConnection()) {
       connection.createStatement().execute("SET AUTOCOMMIT_DML_MODE='PARTITIONED_NON_ATOMIC'");
       connection.createStatement().executeUpdate(UPDATE_STATEMENT.getSql());


### PR DESCRIPTION
The test failure was caused by the fact that the newer version of the Spanner client now uses the `ExecuteStreamingSql` RPC to execute PDML, as opposed to the `ExecuteSql` RPC in previous versions.

Fixes #183
