### PR TITLE
feat: expose more methods from Connection in JDBC

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -42,4 +42,56 @@
     <differenceType>8001</differenceType>
     <className>com/google/cloud/spanner/jdbc/UnitOfWork$UnitOfWorkState</className>
   </difference>
+  
+  <!-- Expose more methods from Connection API in CloudSpannerJdbcConnection -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.connection.AutocommitDmlMode getAutocommitDmlMode()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>java.lang.String getOptimizerVersion()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.TimestampBound getReadOnlyStaleness()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.connection.TransactionMode getTransactionMode()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>boolean isInTransaction()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>boolean isTransactionStarted()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>void setAutocommitDmlMode(com.google.cloud.spanner.connection.AutocommitDmlMode)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>void setOptimizerVersion(java.lang.String)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>void setReadOnlyStaleness(com.google.cloud.spanner.TimestampBound)</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>void setTransactionMode(com.google.cloud.spanner.connection.TransactionMode)</method>
+  </difference>
 </differences>

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -19,8 +19,11 @@ package com.google.cloud.spanner.jdbc;
 import com.google.api.client.util.Preconditions;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.connection.AutocommitDmlMode;
 import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.cloud.spanner.connection.StatementParser;
+import com.google.cloud.spanner.connection.TransactionMode;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import java.sql.Array;
@@ -72,6 +75,66 @@ class JdbcConnection extends AbstractJdbcConnection {
     return JdbcParameterStore.convertPositionalParametersToNamedParameters(
             StatementParser.removeCommentsAndTrim(sql))
         .sqlWithNamedParameters;
+  }
+
+  @Override
+  public void setTransactionMode(TransactionMode mode) throws SQLException {
+    checkClosed();
+    getSpannerConnection().setTransactionMode(mode);
+  }
+
+  @Override
+  public TransactionMode getTransactionMode() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().getTransactionMode();
+  }
+
+  @Override
+  public void setAutocommitDmlMode(AutocommitDmlMode mode) throws SQLException {
+    checkClosed();
+    getSpannerConnection().setAutocommitDmlMode(mode);
+  }
+
+  @Override
+  public AutocommitDmlMode getAutocommitDmlMode() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().getAutocommitDmlMode();
+  }
+
+  @Override
+  public void setReadOnlyStaleness(TimestampBound staleness) throws SQLException {
+    checkClosed();
+    getSpannerConnection().setReadOnlyStaleness(staleness);
+  }
+
+  @Override
+  public TimestampBound getReadOnlyStaleness() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().getReadOnlyStaleness();
+  }
+
+  @Override
+  public void setOptimizerVersion(String optimizerVersion) throws SQLException {
+    checkClosed();
+    getSpannerConnection().setOptimizerVersion(optimizerVersion);
+  }
+
+  @Override
+  public String getOptimizerVersion() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().getOptimizerVersion();
+  }
+
+  @Override
+  public boolean isInTransaction() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().isInTransaction();
+  }
+
+  @Override
+  public boolean isTransactionStarted() throws SQLException {
+    checkClosed();
+    return getSpannerConnection().isTransactionStarted();
   }
 
   @Override


### PR DESCRIPTION
More methods from the Connection API should be exposed in the Cloud Spanner JDBC Connection interface to make it easier to execute read-only transactions with specific timestamp bounds.

This PR relies on [this PR in the client library](https://github.com/googleapis/java-spanner/pull/579) that is needed before this can be merged.

Towards #253
