### PR TITLE
deps: use google-cloud-spanner-bom instead of libraries-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>12.0.0</version>
+        <artifactId>google-cloud-spanner-bom</artifactId>
+        <version>2.0.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
@olavloite, @stephaniewang526, @elharo, @chingor13

As this repository uses the shared dependencies BOM now, google-cloud-spanner-bom has the dependencies necessary to replace the libraries-bom. It's more smaller and will not cause the dependency conflicts that are irrelevant to this repository (motivation: https://github.com/googleapis/java-spanner-jdbc/pull/251#issuecomment-721256007).

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:


- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner-jdbc/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #252  ☕️

