### PR TITLE
chore: remove unused maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,41 +321,6 @@
       </plugins>
     </pluginManagement>
   </build>
-  <profiles>
-    <profile>
-      <!-- Profile for generating new sql test scripts. See ConnectionImplGeneratedSqlScriptTest 
-        for more information. -->
-      <id>generate-test-sql-scripts</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generateTestScripts</id>
-                <phase>compile</phase>
-                <goals>
-                  <goal>java</goal>
-                </goals>
-                <configuration>
-                  <mainClass>com.google.cloud.spanner.jdbc.SqlTestScriptsGenerator</mainClass>
-                  <systemProperties>
-                    <systemProperty>
-                      <key>do_log_statements</key>
-                      <value>true</value>
-                    </systemProperty>
-                  </systemProperties>
-                  <classpathScope>test</classpathScope>
-                  <skip>false</skip>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
This build profile is no longer needed, as it has been moved to the client library together with the general Connection API.
