### PR TITLE
deps: update dependency shared-dependencies to v0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,17 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>0.10.0</version>
+        <version>0.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
@@ -124,10 +128,6 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>


### PR DESCRIPTION
Moves the http-client dependency up to prevent dependency conflict and updates the shared dependencies to v0.15.0. Replaces #237 