### PR TITLE
feat: support default ClientInfo properties

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -53,7 +53,7 @@ class JdbcConnection extends AbstractJdbcConnection {
 
   private Map<String, Class<?>> typeMap = new HashMap<>();
 
-  JdbcConnection(String connectionUrl, ConnectionOptions options) {
+  JdbcConnection(String connectionUrl, ConnectionOptions options) throws SQLException {
     super(connectionUrl, options);
   }
 

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionGeneratedSqlScriptTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionGeneratedSqlScriptTest.java
@@ -19,12 +19,14 @@ package com.google.cloud.spanner.jdbc;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.spanner.connection.AbstractSqlScriptVerifier.GenericConnection;
 import com.google.cloud.spanner.connection.AbstractSqlScriptVerifier.GenericConnectionProvider;
 import com.google.cloud.spanner.connection.ConnectionImplTest;
 import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.cloud.spanner.connection.SqlScriptVerifier;
 import com.google.cloud.spanner.jdbc.JdbcSqlScriptVerifier.JdbcGenericConnection;
+import java.sql.SQLException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,13 +48,17 @@ public class JdbcConnectionGeneratedSqlScriptTest {
       com.google.cloud.spanner.connection.Connection spannerConnection =
           ConnectionImplTest.createConnection(options);
       when(options.getConnection()).thenReturn(spannerConnection);
-      JdbcConnection connection =
-          new JdbcConnection(
-              "jdbc:cloudspanner://localhost/projects/project/instances/instance/databases/database;credentialsUrl=url",
-              options);
-      JdbcGenericConnection res = JdbcGenericConnection.of(connection);
-      res.setStripCommentsBeforeExecute(true);
-      return res;
+      try {
+        JdbcConnection connection =
+            new JdbcConnection(
+                "jdbc:cloudspanner://localhost/projects/project/instances/instance/databases/database;credentialsUrl=url",
+                options);
+        JdbcGenericConnection res = JdbcGenericConnection.of(connection);
+        res.setStripCommentsBeforeExecute(true);
+        return res;
+      } catch (SQLException e) {
+        throw SpannerExceptionFactory.asSpannerException(e);
+      }
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
@@ -322,6 +322,18 @@ public class JdbcDatabaseMetaDataTest {
     JdbcConnection connection = mock(JdbcConnection.class);
     DatabaseMetaData meta = new JdbcDatabaseMetaData(connection);
     try (ResultSet rs = meta.getClientInfoProperties()) {
+      assertThat(rs.next(), is(true));
+      assertThat(rs.getString("NAME"), is(equalTo("APPLICATIONNAME")));
+      assertThat(rs.getString("DEFAULT_VALUE"), is(equalTo("")));
+
+      assertThat(rs.next(), is(true));
+      assertThat(rs.getString("NAME"), is(equalTo("CLIENTHOSTNAME")));
+      assertThat(rs.getString("DEFAULT_VALUE"), is(equalTo("")));
+
+      assertThat(rs.next(), is(true));
+      assertThat(rs.getString("NAME"), is(equalTo("CLIENTUSER")));
+      assertThat(rs.getString("DEFAULT_VALUE"), is(equalTo("")));
+
       assertThat(rs.next(), is(false));
       ResultSetMetaData rsmd = rs.getMetaData();
       assertThat(rsmd.getColumnCount(), is(equalTo(4)));


### PR DESCRIPTION
Adds support for default `ClientInfo` properties. These are not required by the JDBC standard, but many applications (including IntelliJ) will try to set these, and will log a warning if they are not set. This will prevent that warning from being logged.

As a next step, these `ClientInfo` property values should be set as `SessionLabel` values in Cloud Spanner. This makes it possible to track which sessions are being used by which (JDBC) application.