### PR TITLE
feat: Support Array conversion to ResultSet

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcArrayTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcArrayTest.java
@@ -161,6 +161,32 @@ public class JdbcArrayTest {
   }
 
   @Test
+  public void testCreateArrayOfArray() {
+    try {
+      JdbcArray.createArray("ARRAY<STRING>", new String[][] {{}});
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat((Exception) e).isInstanceOf(JdbcSqlException.class);
+      JdbcSqlException jse = (JdbcSqlException) e;
+      assertThat(jse.getErrorCode())
+          .isEqualTo(ErrorCode.INVALID_ARGUMENT.getGrpcStatusCode().value());
+    }
+  }
+
+  @Test
+  public void testCreateArrayOfStruct() {
+    try {
+      JdbcArray.createArray("STRUCT", new Object[] {});
+      fail("missing expected exception");
+    } catch (SQLException e) {
+      assertThat((Exception) e).isInstanceOf(JdbcSqlException.class);
+      JdbcSqlException jse = (JdbcSqlException) e;
+      assertThat(jse.getErrorCode())
+          .isEqualTo(ErrorCode.INVALID_ARGUMENT.getGrpcStatusCode().value());
+    }
+  }
+
+  @Test
   public void testGetResultSetMetadata() throws SQLException {
     JdbcArray array = JdbcArray.createArray("STRING", new String[] {"foo", "bar", "baz"});
     try (ResultSet rs = array.getResultSet()) {


### PR DESCRIPTION
JDBC arrays have an optional method that allow them to be converted to `ResultSet`s. This method was not implemented for the Cloud Spanner JDBC driver. This would cause DBeaver to not be able to fetch and view the data of `NUMERIC` columns, as DBeaver would use this method for specifically those columns (other array columns would work). This PR fixes that specific problem and allows other users to use this convenience method for all array types.

Fixes #332 

![Screenshot from 2021-01-18 12-44-51](https://user-images.githubusercontent.com/1196707/104911616-713bc200-598b-11eb-9acd-9de89fc693b6.png)
