### PR TITLE
feat: support creating shaded jars

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -23,3 +23,14 @@ custom_content: |
      }
    }
    ```
+   
+   ### Creating a Shaded Jar
+   
+   A jar with all dependencies included is automatically generated when you execute `mvn package`.
+   The dependencies in this jar are not shaded. To create a jar with shaded dependencies you must
+   activate the `shade` profile like this:
+   
+    ```
+    mvn package -Pshade
+    ```
+   

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,50 @@
       </plugins>
     </pluginManagement>
   </build>
+  
+  <profiles>
+    <profile>
+      <id>shade</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.com</shadedPattern>
+                  <excludes>
+                    <exclude>com.google.cloud.spanner.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>android</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.android</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.io</shadedPattern>
+                  <excludes>
+                    <exclude>io.grpc.netty.shaded.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.org</shadedPattern>
+                  <excludes>
+                    <exclude>org.conscrypt.**</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
Some applications that load multiple JDBC drivers may run into dependency conflicts if other JDBC drivers use the same dependencies but different versions. This problem can be mitigated by creating a jar with shaded dependencies. This change adds a Maven profile for creating shaded jars.

Fixes #316
