### PR TITLE
Fix: Return entire stack trace for deadline exceeded error

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
@@ -68,8 +68,8 @@ public final class JdbcSqlExceptionFactory {
       implements JdbcSqlException {
     private static final long serialVersionUID = 2363793358642102814L;
 
-    private JdbcSqlTimeoutException(SpannerException cause) {
-      super(cause);
+    private JdbcSqlTimeoutException(SpannerException e) {
+      super(e.getMessage(), "Timed out", Code.DEADLINE_EXCEEDED_VALUE, e);
     }
 
     private JdbcSqlTimeoutException(String message) {

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
@@ -68,6 +68,10 @@ public final class JdbcSqlExceptionFactory {
       implements JdbcSqlException {
     private static final long serialVersionUID = 2363793358642102814L;
 
+    private JdbcSqlTimeoutException(SpannerException cause) {
+      super(cause);
+    }
+
     private JdbcSqlTimeoutException(String message) {
       super(message, "Timed out", Code.DEADLINE_EXCEEDED_VALUE);
     }
@@ -188,7 +192,7 @@ public final class JdbcSqlExceptionFactory {
           return new JdbcAbortedException((AbortedException) e);
         }
       case DEADLINE_EXCEEDED:
-        return new JdbcSqlTimeoutException(e.getMessage());
+        return new JdbcSqlTimeoutException(e);
       case ALREADY_EXISTS:
       case CANCELLED:
       case DATA_LOSS:


### PR DESCRIPTION
Cloud Spanner JDBC Driver stack trace is not clear on cause of the issue when there is a DEADLINE_EXCEEDED error, making it more difficult for the customer and Cloud Support to debug the issue. This PR modifies the exception mapping to return the original exception rather than the message only, so that the entire stack trace is shown.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-spanner-jdbc/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
