### PR TITLE
test: re-enable JDBC converter test

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcTypeConverterTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcTypeConverterTest.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -620,7 +619,6 @@ public class JdbcTypeConverterTest {
     }
   }
 
-  @Ignore("ignore until java-core 1.93.3 is available")
   @SuppressWarnings("deprecation")
   @Test
   public void testToGoogleTimestamp() {


### PR DESCRIPTION
Re-enables a test that had been disabled because of an [issue](https://github.com/googleapis/java-core/pull/179) with pre-epoch Timestamps in java-core.