### PR TITLE
feat: allow using UUID in PreparedStatement

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
@@ -45,6 +45,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 /** This class handles the parameters of a {@link PreparedStatement}. */
 class JdbcParameterStore {
@@ -507,6 +508,8 @@ class JdbcParameterStore {
           }
         } else if (value instanceof URL) {
           return binder.to(((URL) value).toString());
+        } else if (value instanceof UUID) {
+          return binder.to(((UUID) value).toString());
         }
         throw JdbcSqlExceptionFactory.of(value + " is not a valid string", Code.INVALID_ARGUMENT);
       case Types.DATE:
@@ -649,6 +652,8 @@ class JdbcParameterStore {
       return binder.to(String.valueOf((char[]) value));
     } else if (URL.class.isAssignableFrom(value.getClass())) {
       return binder.to(((URL) value).toString());
+    } else if (UUID.class.isAssignableFrom(value.getClass())) {
+      return binder.to(((UUID) value).toString());
     } else if (byte[].class.isAssignableFrom(value.getClass())) {
       return binder.to(ByteArray.copyFrom((byte[]) value));
     } else if (InputStream.class.isAssignableFrom(value.getClass())) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -17,9 +17,9 @@
 package com.google.cloud.spanner.jdbc;
 
 import static com.google.cloud.spanner.jdbc.JdbcParameterStore.convertPositionalParametersToNamedParameters;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.ByteArray;
@@ -44,6 +44,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -58,66 +59,62 @@ public class JdbcParameterStoreTest {
     JdbcParameterStore params = new JdbcParameterStore();
     // test the valid default combinations
     params.setParameter(1, true, Types.BOOLEAN);
-    assertThat((Boolean) params.getParameter(1), is(equalTo(true)));
+    assertTrue((Boolean) params.getParameter(1));
     verifyParameter(params, Value.bool(true));
     params.setParameter(1, (byte) 1, Types.TINYINT);
-    assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+    assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, (short) 1, Types.SMALLINT);
-    assertThat((Short) params.getParameter(1), is(equalTo((short) 1)));
+    assertEquals(1, ((Short) params.getParameter(1)).shortValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, 1, Types.INTEGER);
-    assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+    assertEquals(1, ((Integer) params.getParameter(1)).intValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, 1L, Types.BIGINT);
-    assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+    assertEquals(1, ((Long) params.getParameter(1)).longValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, (float) 1, Types.FLOAT);
-    assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+    assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
     verifyParameter(params, Value.float64(1));
     params.setParameter(1, (double) 1, Types.DOUBLE);
-    assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+    assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
     verifyParameter(params, Value.float64(1));
     params.setParameter(1, new Date(1970 - 1900, 0, 1), Types.DATE);
-    assertThat((Date) params.getParameter(1), is(equalTo(new Date(1970 - 1900, 0, 1))));
+    assertEquals(new Date(1970 - 1900, 0, 1), params.getParameter(1));
     verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
     params.setParameter(1, new Time(0L), Types.TIME);
-    assertThat((Time) params.getParameter(1), is(equalTo(new Time(0L))));
+    assertEquals(new Time(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     params.setParameter(1, new Timestamp(0L), Types.TIMESTAMP);
-    assertThat((Timestamp) params.getParameter(1), is(equalTo(new Timestamp(0L))));
+    assertEquals(new Timestamp(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     params.setParameter(1, new byte[] {1, 2, 3}, Types.BINARY);
-    assertThat((byte[]) params.getParameter(1), is(equalTo(new byte[] {1, 2, 3})));
+    assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
     params.setParameter(1, "test", Types.NVARCHAR);
-    assertThat((String) params.getParameter(1), is(equalTo("test")));
+    assertEquals("test", params.getParameter(1));
     verifyParameter(params, Value.string("test"));
 
     params.setParameter(1, new JdbcBlob(new byte[] {1, 2, 3}), Types.BLOB);
-    assertThat((JdbcBlob) params.getParameter(1), is(equalTo(new JdbcBlob(new byte[] {1, 2, 3}))));
+    assertEquals(new JdbcBlob(new byte[] {1, 2, 3}), params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
     params.setParameter(1, new ByteArrayInputStream(new byte[] {1, 2, 3}), Types.BLOB);
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
 
     params.setParameter(1, new JdbcClob("test"), Types.CLOB);
-    assertThat((JdbcClob) params.getParameter(1), is(equalTo(new JdbcClob("test"))));
+    assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
     params.setParameter(1, new StringReader("test"), Types.CLOB);
-    assertThat(
-        stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")),
-        is(true));
+    assertTrue(stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")));
     verifyParameter(params, Value.string("test"));
 
     params.setParameter(1, new JdbcClob("test"), Types.NCLOB);
-    assertThat((JdbcClob) params.getParameter(1), is(equalTo(new JdbcClob("test"))));
+    assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
     params.setParameter(1, new StringReader("test"), Types.NCLOB);
-    assertThat(
-        stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")),
-        is(true));
+    assertTrue(stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")));
     verifyParameter(params, Value.string("test"));
 
     params.setParameter(1, BigDecimal.ONE, Types.DECIMAL);
@@ -126,80 +123,78 @@ public class JdbcParameterStoreTest {
     // types that should lead to int64
     for (int type : new int[] {Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT}) {
       params.setParameter(1, (byte) 1, type);
-      assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+      assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, (short) 1, type);
-      assertThat((Short) params.getParameter(1), is(equalTo((short) 1)));
+      assertEquals(1, ((Short) params.getParameter(1)).shortValue());
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, 1, type);
-      assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+      assertEquals(1, ((Integer) params.getParameter(1)).intValue());
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, 1L, type);
-      assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+      assertEquals(1, ((Long) params.getParameter(1)).longValue());
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, (float) 1, type);
-      assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+      assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, (double) 1, type);
-      assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+      assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
       verifyParameter(params, Value.int64(1));
       params.setParameter(1, BigDecimal.ONE, type);
-      assertThat((BigDecimal) params.getParameter(1), is(equalTo(BigDecimal.ONE)));
+      assertEquals(BigDecimal.ONE, params.getParameter(1));
       verifyParameter(params, Value.int64(1));
     }
 
     // types that should lead to float64
     for (int type : new int[] {Types.FLOAT, Types.REAL, Types.DOUBLE}) {
       params.setParameter(1, (byte) 1, type);
-      assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+      assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, (short) 1, type);
-      assertThat((Short) params.getParameter(1), is(equalTo((short) 1)));
+      assertEquals(1, ((Short) params.getParameter(1)).shortValue());
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, 1, type);
-      assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+      assertEquals(1, ((Integer) params.getParameter(1)).intValue());
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, 1L, type);
-      assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+      assertEquals(1, ((Long) params.getParameter(1)).longValue());
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, (float) 1, type);
-      assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+      assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, (double) 1, type);
-      assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+      assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
       verifyParameter(params, Value.float64(1));
       params.setParameter(1, BigDecimal.ONE, type);
-      assertThat((BigDecimal) params.getParameter(1), is(equalTo(BigDecimal.ONE)));
+      assertEquals(BigDecimal.ONE, params.getParameter(1));
       verifyParameter(params, Value.float64(1));
     }
 
     // types that should lead to date
     for (int type : new int[] {Types.DATE}) {
       params.setParameter(1, new Date(1970 - 1900, 0, 1), type);
-      assertThat((Date) params.getParameter(1), is(equalTo(new Date(1970 - 1900, 0, 1))));
+      assertEquals(new Date(1970 - 1900, 0, 1), params.getParameter(1));
       verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
       params.setParameter(1, new Time(0L), type);
-      assertThat((Time) params.getParameter(1), is(equalTo(new Time(0L))));
+      assertEquals(new Time(0L), params.getParameter(1));
       verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
       params.setParameter(1, new Timestamp(1970 - 1900, 0, 1, 0, 0, 0, 0), type);
-      assertThat(
-          (Timestamp) params.getParameter(1),
-          is(equalTo(new Timestamp(1970 - 1900, 0, 1, 0, 0, 0, 0))));
+      assertEquals(new Timestamp(1970 - 1900, 0, 1, 0, 0, 0, 0), params.getParameter(1));
       verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
     }
 
     // types that should lead to timestamp
     for (int type : new int[] {Types.TIME, Types.TIMESTAMP}) {
       params.setParameter(1, new Date(0L), type);
-      assertThat((Date) params.getParameter(1), is(equalTo(new Date(0L))));
+      assertEquals(new Date(0L), params.getParameter(1));
       verifyParameter(
           params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
       params.setParameter(1, new Time(0L), type);
-      assertThat((Time) params.getParameter(1), is(equalTo(new Time(0L))));
+      assertEquals(new Time(0L), params.getParameter(1));
       verifyParameter(
           params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
       params.setParameter(1, new Timestamp(0L), type);
-      assertThat((Timestamp) params.getParameter(1), is(equalTo(new Timestamp(0L))));
+      assertEquals(new Timestamp(0L), params.getParameter(1));
       verifyParameter(
           params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     }
@@ -207,7 +202,7 @@ public class JdbcParameterStoreTest {
     // types that should lead to bytes (except BLOB which is handled separately)
     for (int type : new int[] {Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY}) {
       params.setParameter(1, new byte[] {1, 2, 3}, type);
-      assertThat((byte[]) params.getParameter(1), is(equalTo(new byte[] {1, 2, 3})));
+      assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) params.getParameter(1));
       verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
     }
 
@@ -222,81 +217,78 @@ public class JdbcParameterStoreTest {
           Types.LONGNVARCHAR
         }) {
       params.setParameter(1, "test", type);
-      assertThat((String) params.getParameter(1), is(equalTo("test")));
+      assertEquals("test", params.getParameter(1));
       verifyParameter(params, Value.string("test"));
 
       params.setParameter(1, new StringReader("test"), type);
-      assertThat(
-          stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")),
-          is(true));
+      assertTrue(
+          stringReadersEqual((StringReader) params.getParameter(1), new StringReader("test")));
       verifyParameter(params, Value.string("test"));
 
       params.setParameter(
           1, new ByteArrayInputStream(StandardCharsets.US_ASCII.encode("test").array()), type);
-      assertThat(
+      assertTrue(
           asciiStreamsEqual(
               (ByteArrayInputStream) params.getParameter(1),
-              new ByteArrayInputStream(StandardCharsets.US_ASCII.encode("test").array())),
-          is(true));
+              new ByteArrayInputStream(StandardCharsets.US_ASCII.encode("test").array())));
       verifyParameter(params, Value.string("test"));
 
       params.setParameter(1, new URL("https://cloud.google.com/spanner"), type);
-      assertThat(
-          (URL) params.getParameter(1), is(equalTo(new URL("https://cloud.google.com/spanner"))));
+      assertEquals(new URL("https://cloud.google.com/spanner"), params.getParameter(1));
       verifyParameter(params, Value.string("https://cloud.google.com/spanner"));
     }
 
     // types that should lead to bool
     for (int type : new int[] {Types.BOOLEAN, Types.BIT}) {
       params.setParameter(1, true, type);
-      assertThat((Boolean) params.getParameter(1), is(equalTo(true)));
+      assertTrue((Boolean) params.getParameter(1));
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, (byte) 1, type);
-      assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+      assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, (short) 0, type);
-      assertThat((Short) params.getParameter(1), is(equalTo((short) 0)));
+      assertEquals(0, ((Short) params.getParameter(1)).shortValue());
       verifyParameter(params, Value.bool(false));
       params.setParameter(1, 1, type);
-      assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+      assertEquals(1, ((Integer) params.getParameter(1)).intValue());
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, 1L, type);
-      assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+      assertEquals(1, ((Long) params.getParameter(1)).longValue());
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, (float) 1, type);
-      assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+      assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, (double) 1, type);
-      assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+      assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
       verifyParameter(params, Value.bool(true));
       params.setParameter(1, BigDecimal.ZERO, type);
-      assertThat((BigDecimal) params.getParameter(1), is(equalTo(BigDecimal.ZERO)));
+      assertEquals(BigDecimal.ZERO, params.getParameter(1));
       verifyParameter(params, Value.bool(false));
     }
 
     // types that should lead to numeric
     for (int type : new int[] {Types.DECIMAL, Types.NUMERIC}) {
       params.setParameter(1, BigDecimal.ONE, type);
-      assertThat((BigDecimal) params.getParameter(1), is(equalTo(BigDecimal.ONE)));
+      assertEquals(BigDecimal.ONE, params.getParameter(1));
       verifyParameter(params, Value.numeric(BigDecimal.ONE));
 
       params.setParameter(1, (byte) 1, type);
-      assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+      assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
       verifyParameter(params, Value.numeric(BigDecimal.ONE));
       params.setParameter(1, (short) 1, type);
-      assertThat((Short) params.getParameter(1), is(equalTo((short) 1)));
+      assertEquals(1, ((Short) params.getParameter(1)).shortValue());
       verifyParameter(params, Value.numeric(BigDecimal.ONE));
       params.setParameter(1, 1, type);
-      assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+      assertEquals(1, ((Integer) params.getParameter(1)).intValue());
       verifyParameter(params, Value.numeric(BigDecimal.ONE));
       params.setParameter(1, 1L, type);
-      assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+      assertEquals(1, ((Long) params.getParameter(1)).longValue());
       verifyParameter(params, Value.numeric(BigDecimal.ONE));
       params.setParameter(1, (float) 1, type);
-      assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+      assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
       verifyParameter(params, Value.numeric(BigDecimal.valueOf(1.0)));
       params.setParameter(1, (double) 1, type);
-      assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+      assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
       verifyParameter(params, Value.numeric(BigDecimal.valueOf(1.0)));
     }
   }
@@ -404,7 +396,7 @@ public class JdbcParameterStoreTest {
       params.setParameter(1, value, type);
       fail("missing expected exception");
     } catch (JdbcSqlExceptionImpl e) {
-      assertThat(e.getCode(), is(equalTo(Code.INVALID_ARGUMENT)));
+      assertEquals(Code.INVALID_ARGUMENT, e.getCode());
     }
   }
 
@@ -417,53 +409,56 @@ public class JdbcParameterStoreTest {
   public void testSetParameterWithoutType() throws SQLException {
     JdbcParameterStore params = new JdbcParameterStore();
     params.setParameter(1, (byte) 1, null);
-    assertThat((Byte) params.getParameter(1), is(equalTo((byte) 1)));
+    assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, (short) 1, null);
-    assertThat((Short) params.getParameter(1), is(equalTo((short) 1)));
+    assertEquals(1, ((Short) params.getParameter(1)).shortValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, 1, null);
-    assertThat((Integer) params.getParameter(1), is(equalTo(1)));
+    assertEquals(1, ((Integer) params.getParameter(1)).intValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, 1L, null);
-    assertThat((Long) params.getParameter(1), is(equalTo(1L)));
+    assertEquals(1, ((Long) params.getParameter(1)).longValue());
     verifyParameter(params, Value.int64(1));
     params.setParameter(1, (float) 1, null);
-    assertThat((Float) params.getParameter(1), is(equalTo((float) 1)));
+    assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
     verifyParameter(params, Value.float64(1));
     params.setParameter(1, (double) 1, null);
-    assertThat((Double) params.getParameter(1), is(equalTo((double) 1)));
+    assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
     verifyParameter(params, Value.float64(1));
     params.setParameter(1, new Date(1970 - 1900, 0, 1), null);
-    assertThat((Date) params.getParameter(1), is(equalTo(new Date(1970 - 1900, 0, 1))));
+    assertEquals(new Date(1970 - 1900, 0, 1), params.getParameter(1));
     verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
     params.setParameter(1, new Time(0L), null);
-    assertThat((Time) params.getParameter(1), is(equalTo(new Time(0L))));
+    assertEquals(new Time(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     params.setParameter(1, new Timestamp(0L), null);
-    assertThat((Timestamp) params.getParameter(1), is(equalTo(new Timestamp(0L))));
+    assertEquals(new Timestamp(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     params.setParameter(1, new byte[] {1, 2, 3}, null);
-    assertThat((byte[]) params.getParameter(1), is(equalTo(new byte[] {1, 2, 3})));
+    assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
 
     params.setParameter(1, new JdbcBlob(new byte[] {1, 2, 3}), null);
-    assertThat((JdbcBlob) params.getParameter(1), is(equalTo(new JdbcBlob(new byte[] {1, 2, 3}))));
+    assertEquals(new JdbcBlob(new byte[] {1, 2, 3}), params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
     params.setParameter(1, new JdbcClob("test"), null);
-    assertThat((JdbcClob) params.getParameter(1), is(equalTo(new JdbcClob("test"))));
+    assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
     params.setParameter(1, true, null);
-    assertThat((Boolean) params.getParameter(1), is(equalTo(true)));
+    assertTrue((Boolean) params.getParameter(1));
     verifyParameter(params, Value.bool(true));
     params.setParameter(1, "test", null);
-    assertThat((String) params.getParameter(1), is(equalTo("test")));
+    assertEquals("test", params.getParameter(1));
     verifyParameter(params, Value.string("test"));
     params.setParameter(1, new JdbcClob("test"), null);
-    assertThat((JdbcClob) params.getParameter(1), is(equalTo(new JdbcClob("test"))));
+    assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
+    params.setParameter(1, UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"), null);
+    assertEquals(UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"), params.getParameter(1));
+    verifyParameter(params, Value.string("83b988cf-1f4e-428a-be3d-cc712621942e"));
   }
 
   private boolean stringReadersEqual(StringReader r1, StringReader r2) throws IOException {
@@ -489,110 +484,92 @@ public class JdbcParameterStoreTest {
     JdbcParameterStore params = new JdbcParameterStore();
     params.setParameter(
         1, JdbcArray.createArray("BOOL", new Boolean[] {true, false, true}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("BOOL", new Boolean[] {true, false, true}))));
+    assertEquals(
+        JdbcArray.createArray("BOOL", new Boolean[] {true, false, true}), params.getParameter(1));
     verifyParameter(params, Value.boolArray(new boolean[] {true, false, true}));
 
     params.setParameter(
         1, JdbcArray.createArray("BOOL", new Boolean[] {true, false, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("BOOL", new Boolean[] {true, false, null}))));
+    assertEquals(
+        JdbcArray.createArray("BOOL", new Boolean[] {true, false, null}), params.getParameter(1));
     verifyParameter(params, Value.boolArray(Arrays.asList(true, false, null)));
 
     params.setParameter(1, JdbcArray.createArray("BOOL", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("BOOL", null))));
+    assertEquals(JdbcArray.createArray("BOOL", null), params.getParameter(1));
     verifyParameter(params, Value.boolArray((boolean[]) null));
 
     params.setParameter(1, JdbcArray.createArray("INT64", new Long[] {1L, 2L, 3L}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("INT64", new Long[] {1L, 2L, 3L}))));
+    assertEquals(JdbcArray.createArray("INT64", new Long[] {1L, 2L, 3L}), params.getParameter(1));
     verifyParameter(params, Value.int64Array(new long[] {1, 2, 3}));
 
     params.setParameter(1, JdbcArray.createArray("INT64", new Long[] {1L, 2L, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("INT64", new Long[] {1L, 2L, null}))));
+    assertEquals(JdbcArray.createArray("INT64", new Long[] {1L, 2L, null}), params.getParameter(1));
     verifyParameter(params, Value.int64Array(Arrays.asList(1L, 2L, null)));
 
     params.setParameter(1, JdbcArray.createArray("INT64", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("INT64", null))));
+    assertEquals(JdbcArray.createArray("INT64", null), params.getParameter(1));
     verifyParameter(params, Value.int64Array((long[]) null));
 
     params.setParameter(
         1, JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, 3D}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, 3D}))));
+    assertEquals(
+        JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, 3D}), params.getParameter(1));
     verifyParameter(params, Value.float64Array(new double[] {1, 2, 3}));
 
     params.setParameter(
         1, JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, null}))));
+    assertEquals(
+        JdbcArray.createArray("FLOAT64", new Double[] {1D, 2D, null}), params.getParameter(1));
     verifyParameter(params, Value.float64Array(Arrays.asList(1D, 2D, null)));
 
     params.setParameter(1, JdbcArray.createArray("FLOAT64", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("FLOAT64", null))));
+    assertEquals(JdbcArray.createArray("FLOAT64", null), params.getParameter(1));
     verifyParameter(params, Value.float64Array((double[]) null));
 
     @SuppressWarnings("deprecation")
     Date sqlDate = new Date(2018 - 1900, 12 - 1, 14);
     params.setParameter(1, JdbcArray.createArray("DATE", new Date[] {sqlDate}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("DATE", new Date[] {sqlDate}))));
+    assertEquals(JdbcArray.createArray("DATE", new Date[] {sqlDate}), params.getParameter(1));
     verifyParameter(
         params,
         Value.dateArray(Arrays.asList(com.google.cloud.Date.fromYearMonthDay(2018, 12, 14))));
 
     params.setParameter(1, JdbcArray.createArray("DATE", new Date[] {sqlDate, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("DATE", new Date[] {sqlDate, null}))));
+    assertEquals(JdbcArray.createArray("DATE", new Date[] {sqlDate, null}), params.getParameter(1));
     verifyParameter(
         params,
         Value.dateArray(Arrays.asList(com.google.cloud.Date.fromYearMonthDay(2018, 12, 14), null)));
 
     params.setParameter(1, JdbcArray.createArray("DATE", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("DATE", null))));
+    assertEquals(JdbcArray.createArray("DATE", null), params.getParameter(1));
     verifyParameter(params, Value.dateArray(null));
 
     Timestamp sqlTimestamp = new Timestamp(System.currentTimeMillis());
     params.setParameter(
         1, JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp}))));
+    assertEquals(
+        JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp}), params.getParameter(1));
     verifyParameter(
         params, Value.timestampArray(Arrays.asList(com.google.cloud.Timestamp.of(sqlTimestamp))));
 
     params.setParameter(
         1, JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp, null}))));
+    assertEquals(
+        JdbcArray.createArray("TIMESTAMP", new Timestamp[] {sqlTimestamp, null}),
+        params.getParameter(1));
     verifyParameter(
         params,
         Value.timestampArray(Arrays.asList(com.google.cloud.Timestamp.of(sqlTimestamp), null)));
 
     params.setParameter(1, JdbcArray.createArray("TIMESTAMP", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("TIMESTAMP", null))));
+    assertEquals(JdbcArray.createArray("TIMESTAMP", null), params.getParameter(1));
     verifyParameter(params, Value.timestampArray(null));
 
     params.setParameter(
         1, JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}}))));
+    assertEquals(
+        JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}}),
+        params.getParameter(1));
     verifyParameter(
         params,
         Value.bytesArray(
@@ -602,9 +579,9 @@ public class JdbcParameterStoreTest {
 
     params.setParameter(
         1, JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}, null}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}, null}))));
+    assertEquals(
+        JdbcArray.createArray("BYTES", new byte[][] {{1, 2, 3}, {4, 5, 6}, null}),
+        params.getParameter(1));
     verifyParameter(
         params,
         Value.bytesArray(
@@ -614,38 +591,34 @@ public class JdbcParameterStoreTest {
                 null)));
 
     params.setParameter(1, JdbcArray.createArray("BYTES", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("BYTES", null))));
+    assertEquals(JdbcArray.createArray("BYTES", null), params.getParameter(1));
     verifyParameter(params, Value.bytesArray(null));
 
     params.setParameter(
         1, JdbcArray.createArray("STRING", new String[] {"test1", "test2", "test3"}), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(equalTo(JdbcArray.createArray("STRING", new String[] {"test1", "test2", "test3"}))));
+    assertEquals(
+        JdbcArray.createArray("STRING", new String[] {"test1", "test2", "test3"}),
+        params.getParameter(1));
     verifyParameter(params, Value.stringArray(Arrays.asList("test1", "test2", "test3")));
 
     params.setParameter(
         1,
         JdbcArray.createArray("STRING", new String[] {"test1", null, "test2", "test3"}),
         Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1),
-        is(
-            equalTo(
-                JdbcArray.createArray("STRING", new String[] {"test1", null, "test2", "test3"}))));
+    assertEquals(
+        JdbcArray.createArray("STRING", new String[] {"test1", null, "test2", "test3"}),
+        params.getParameter(1));
     verifyParameter(params, Value.stringArray(Arrays.asList("test1", null, "test2", "test3")));
 
     params.setParameter(1, JdbcArray.createArray("STRING", null), Types.ARRAY);
-    assertThat(
-        (JdbcArray) params.getParameter(1), is(equalTo(JdbcArray.createArray("STRING", null))));
+    assertEquals(JdbcArray.createArray("STRING", null), params.getParameter(1));
     verifyParameter(params, Value.stringArray(null));
   }
 
   private void verifyParameter(JdbcParameterStore params, Value value) throws SQLException {
     Statement.Builder builder = Statement.newBuilder("SELECT * FROM FOO WHERE BAR=:p1");
     params.bindParameterValue(builder.bind("p1"), 1);
-    assertThat(builder.build().getParameters().get("p1"), is(equalTo(value)));
+    assertEquals(value, builder.build().getParameters().get("p1"));
   }
 
   private void verifyParameterBindFails(JdbcParameterStore params) throws SQLException {
@@ -654,80 +627,82 @@ public class JdbcParameterStoreTest {
       params.bindParameterValue(builder.bind("p1"), 1);
       fail("missing expected exception");
     } catch (JdbcSqlExceptionImpl e) {
-      assertThat(e.getCode(), is(equalTo(Code.INVALID_ARGUMENT)));
+      assertEquals(Code.INVALID_ARGUMENT, e.getCode());
     }
   }
 
   @Test
   public void testConvertPositionalParametersToNamedParameters() throws SQLException {
-    assertThat(
+    assertEquals(
+        "select * from foo where name=@p1",
         convertPositionalParametersToNamedParameters("select * from foo where name=?")
-            .sqlWithNamedParameters,
-        is(equalTo("select * from foo where name=@p1")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "@p1'?test?\"?test?\"?'@p2",
         convertPositionalParametersToNamedParameters("?'?test?\"?test?\"?'?")
-            .sqlWithNamedParameters,
-        is(equalTo("@p1'?test?\"?test?\"?'@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?'?it\\'?s'?").sqlWithNamedParameters,
-        is(equalTo("@p1'?it\\'?s'@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?'?it\\\"?s'?").sqlWithNamedParameters,
-        is(equalTo("@p1'?it\\\"?s'@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?\"?it\\\"?s\"?").sqlWithNamedParameters,
-        is(equalTo("@p1\"?it\\\"?s\"@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?`?it\\`?s`?").sqlWithNamedParameters,
-        is(equalTo("@p1`?it\\`?s`@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?'''?it\\'?s'''?").sqlWithNamedParameters,
-        is(equalTo("@p1'''?it\\'?s'''@p2")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "@p1'?it\\'?s'@p2",
+        convertPositionalParametersToNamedParameters("?'?it\\'?s'?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1'?it\\\"?s'@p2",
+        convertPositionalParametersToNamedParameters("?'?it\\\"?s'?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1\"?it\\\"?s\"@p2",
+        convertPositionalParametersToNamedParameters("?\"?it\\\"?s\"?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1`?it\\`?s`@p2",
+        convertPositionalParametersToNamedParameters("?`?it\\`?s`?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1'''?it\\'?s'''@p2",
+        convertPositionalParametersToNamedParameters("?'''?it\\'?s'''?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1\"\"\"?it\\\"?s\"\"\"@p2",
         convertPositionalParametersToNamedParameters("?\"\"\"?it\\\"?s\"\"\"?")
-            .sqlWithNamedParameters,
-        is(equalTo("@p1\"\"\"?it\\\"?s\"\"\"@p2")));
-    assertThat(
-        convertPositionalParametersToNamedParameters("?```?it\\`?s```?").sqlWithNamedParameters,
-        is(equalTo("@p1```?it\\`?s```@p2")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "@p1```?it\\`?s```@p2",
+        convertPositionalParametersToNamedParameters("?```?it\\`?s```?").sqlWithNamedParameters);
+    assertEquals(
+        "@p1'''?it\\'?s \n ?it\\'?s'''@p2",
         convertPositionalParametersToNamedParameters("?'''?it\\'?s \n ?it\\'?s'''?")
-            .sqlWithNamedParameters,
-        is(equalTo("@p1'''?it\\'?s \n ?it\\'?s'''@p2")));
+            .sqlWithNamedParameters);
 
     assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s'?");
     assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s?");
     assertUnclosedLiteral("?'''?it\\'?s \n ?it\\'?s'?");
 
-    assertThat(
+    assertEquals(
+        "select 1, @p1, 'test?test', \"test?test\", foo.* from `foo` where col1=@p2 and col2='test' and col3=@p3 and col4='?' and col5=\"?\" and col6='?''?''?'",
         convertPositionalParametersToNamedParameters(
                 "select 1, ?, 'test?test', \"test?test\", foo.* from `foo` where col1=? and col2='test' and col3=? and col4='?' and col5=\"?\" and col6='?''?''?'")
-            .sqlWithNamedParameters,
-        is(
-            equalTo(
-                "select 1, @p1, 'test?test', \"test?test\", foo.* from `foo` where col1=@p2 and col2='test' and col3=@p3 and col4='?' and col5=\"?\" and col6='?''?''?'")));
+            .sqlWithNamedParameters);
 
-    assertThat(
+    assertEquals(
+        "select * " + "from foo " + "where name=@p1 " + "and col2 like @p2 " + "and col3 > @p3",
         convertPositionalParametersToNamedParameters(
                 "select * " + "from foo " + "where name=? " + "and col2 like ? " + "and col3 > ?")
-            .sqlWithNamedParameters,
-        is(
-            equalTo(
-                "select * "
-                    + "from foo "
-                    + "where name=@p1 "
-                    + "and col2 like @p2 "
-                    + "and col3 > @p3")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "select * " + "from foo " + "where id between @p1 and @p2",
         convertPositionalParametersToNamedParameters(
                 "select * " + "from foo " + "where id between ? and ?")
-            .sqlWithNamedParameters,
-        is(equalTo("select * " + "from foo " + "where id between @p1 and @p2")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "select * " + "from foo " + "limit @p1 offset @p2",
         convertPositionalParametersToNamedParameters("select * " + "from foo " + "limit ? offset ?")
-            .sqlWithNamedParameters,
-        is(equalTo("select * " + "from foo " + "limit @p1 offset @p2")));
-    assertThat(
+            .sqlWithNamedParameters);
+    assertEquals(
+        "select * "
+            + "from foo "
+            + "where col1=@p1 "
+            + "and col2 like @p2 "
+            + "and col3 > @p3 "
+            + "and col4 < @p4 "
+            + "and col5 != @p5 "
+            + "and col6 not in (@p6, @p7, @p8) "
+            + "and col7 in (@p9, @p10, @p11) "
+            + "and col8 between @p12 and @p13",
         convertPositionalParametersToNamedParameters(
                 "select * "
                     + "from foo "
@@ -739,19 +714,7 @@ public class JdbcParameterStoreTest {
                     + "and col6 not in (?, ?, ?) "
                     + "and col7 in (?, ?, ?) "
                     + "and col8 between ? and ?")
-            .sqlWithNamedParameters,
-        is(
-            equalTo(
-                "select * "
-                    + "from foo "
-                    + "where col1=@p1 "
-                    + "and col2 like @p2 "
-                    + "and col3 > @p3 "
-                    + "and col4 < @p4 "
-                    + "and col5 != @p5 "
-                    + "and col6 not in (@p6, @p7, @p8) "
-                    + "and col7 in (@p9, @p10, @p11) "
-                    + "and col8 between @p12 and @p13")));
+            .sqlWithNamedParameters);
   }
 
   private void assertUnclosedLiteral(String sql) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.spanner.jdbc;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -49,7 +50,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.TimeZone;
-import org.junit.Assert;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -148,94 +149,89 @@ public class JdbcPreparedStatementTest {
       ps.setTimestamp(46, new Timestamp(1000l), Calendar.getInstance(TimeZone.getTimeZone("GMT")));
       ps.setUnicodeStream(47, new ByteArrayInputStream("TEST".getBytes()), 4);
       ps.setURL(48, new URL("https://spanner.google.com"));
+      ps.setObject(49, UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"));
 
       testSetUnsupportedTypes(ps);
 
       JdbcParameterMetaData pmd = ps.getParameterMetaData();
-      Assert.assertEquals(numberOfParams, pmd.getParameterCount());
-      Assert.assertEquals(JdbcArray.class.getName(), pmd.getParameterClassName(1));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(2));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(3));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(4));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(6));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(7));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(8));
-      Assert.assertEquals(JdbcBlob.class.getName(), pmd.getParameterClassName(9));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(10));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(11));
-      Assert.assertEquals(Boolean.class.getName(), pmd.getParameterClassName(12));
-      Assert.assertEquals(Byte.class.getName(), pmd.getParameterClassName(13));
-      Assert.assertEquals(byte[].class.getName(), pmd.getParameterClassName(14));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(15));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(16));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(17));
-      Assert.assertEquals(JdbcClob.class.getName(), pmd.getParameterClassName(18));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(19));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(20));
-      Assert.assertEquals(Date.class.getName(), pmd.getParameterClassName(21));
-      Assert.assertEquals(Date.class.getName(), pmd.getParameterClassName(22));
-      Assert.assertEquals(Double.class.getName(), pmd.getParameterClassName(23));
-      Assert.assertEquals(Float.class.getName(), pmd.getParameterClassName(24));
-      Assert.assertEquals(Integer.class.getName(), pmd.getParameterClassName(25));
-      Assert.assertEquals(Long.class.getName(), pmd.getParameterClassName(26));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(27));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(28));
-      Assert.assertEquals(JdbcClob.class.getName(), pmd.getParameterClassName(29));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(30));
-      Assert.assertEquals(StringReader.class.getName(), pmd.getParameterClassName(31));
-      Assert.assertEquals(String.class.getName(), pmd.getParameterClassName(32));
-      Assert.assertEquals(Long.class.getName(), pmd.getParameterClassName(33));
-      Assert.assertEquals(Long.class.getName(), pmd.getParameterClassName(34));
-      Assert.assertEquals(String.class.getName(), pmd.getParameterClassName(35));
-      Assert.assertEquals(String.class.getName(), pmd.getParameterClassName(36));
-      Assert.assertEquals(String.class.getName(), pmd.getParameterClassName(37));
-      Assert.assertNull(pmd.getParameterClassName(38));
-      Assert.assertNull(pmd.getParameterClassName(39));
-      Assert.assertEquals(Short.class.getName(), pmd.getParameterClassName(40));
-      Assert.assertNull(pmd.getParameterClassName(41));
-      Assert.assertEquals(String.class.getName(), pmd.getParameterClassName(42));
-      Assert.assertEquals(Time.class.getName(), pmd.getParameterClassName(43));
-      Assert.assertEquals(Time.class.getName(), pmd.getParameterClassName(44));
-      Assert.assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(45));
-      Assert.assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(46));
-      Assert.assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(47));
-      Assert.assertEquals(URL.class.getName(), pmd.getParameterClassName(48));
+      assertEquals(numberOfParams, pmd.getParameterCount());
+      assertEquals(JdbcArray.class.getName(), pmd.getParameterClassName(1));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(2));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(3));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(4));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(6));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(7));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(8));
+      assertEquals(JdbcBlob.class.getName(), pmd.getParameterClassName(9));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(10));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(11));
+      assertEquals(Boolean.class.getName(), pmd.getParameterClassName(12));
+      assertEquals(Byte.class.getName(), pmd.getParameterClassName(13));
+      assertEquals(byte[].class.getName(), pmd.getParameterClassName(14));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(15));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(16));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(17));
+      assertEquals(JdbcClob.class.getName(), pmd.getParameterClassName(18));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(19));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(20));
+      assertEquals(Date.class.getName(), pmd.getParameterClassName(21));
+      assertEquals(Date.class.getName(), pmd.getParameterClassName(22));
+      assertEquals(Double.class.getName(), pmd.getParameterClassName(23));
+      assertEquals(Float.class.getName(), pmd.getParameterClassName(24));
+      assertEquals(Integer.class.getName(), pmd.getParameterClassName(25));
+      assertEquals(Long.class.getName(), pmd.getParameterClassName(26));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(27));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(28));
+      assertEquals(JdbcClob.class.getName(), pmd.getParameterClassName(29));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(30));
+      assertEquals(StringReader.class.getName(), pmd.getParameterClassName(31));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(32));
+      assertEquals(Long.class.getName(), pmd.getParameterClassName(33));
+      assertEquals(Long.class.getName(), pmd.getParameterClassName(34));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(35));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(36));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(37));
+      assertNull(pmd.getParameterClassName(38));
+      assertNull(pmd.getParameterClassName(39));
+      assertEquals(Short.class.getName(), pmd.getParameterClassName(40));
+      assertNull(pmd.getParameterClassName(41));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(42));
+      assertEquals(Time.class.getName(), pmd.getParameterClassName(43));
+      assertEquals(Time.class.getName(), pmd.getParameterClassName(44));
+      assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(45));
+      assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(46));
+      assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(47));
+      assertEquals(URL.class.getName(), pmd.getParameterClassName(48));
+      assertEquals(UUID.class.getName(), pmd.getParameterClassName(49));
 
       ps.clearParameters();
       pmd = ps.getParameterMetaData();
-      Assert.assertEquals(numberOfParams, pmd.getParameterCount());
+      assertEquals(numberOfParams, pmd.getParameterCount());
     }
   }
 
   private void testSetUnsupportedTypes(PreparedStatement ps) {
-    // TODO: Rewrite these tests using functional interfaces when Java8 is available.
-    boolean expectedException = false;
     try {
       ps.setRef(38, (Ref) null);
+      fail("missing expected exception");
     } catch (SQLException e) {
-      if (e instanceof JdbcSqlException) {
-        expectedException = ((JdbcSqlException) e).getCode() == Code.INVALID_ARGUMENT;
-      }
+      assertTrue(e instanceof JdbcSqlException);
+      assertEquals(Code.INVALID_ARGUMENT, ((JdbcSqlException) e).getCode());
     }
-    assertThat(expectedException, is(true));
-    expectedException = false;
     try {
       ps.setRowId(39, (RowId) null);
+      fail("missing expected exception");
     } catch (SQLException e) {
-      if (e instanceof JdbcSqlException) {
-        expectedException = ((JdbcSqlException) e).getCode() == Code.INVALID_ARGUMENT;
-      }
+      assertTrue(e instanceof JdbcSqlException);
+      assertEquals(Code.INVALID_ARGUMENT, ((JdbcSqlException) e).getCode());
     }
-    assertThat(expectedException, is(true));
-    expectedException = false;
     try {
       ps.setSQLXML(41, (SQLXML) null);
+      fail("missing expected exception");
     } catch (SQLException e) {
-      if (e instanceof JdbcSqlException) {
-        expectedException = ((JdbcSqlException) e).getCode() == Code.INVALID_ARGUMENT;
-      }
+      assertTrue(e instanceof JdbcSqlException);
+      assertEquals(Code.INVALID_ARGUMENT, ((JdbcSqlException) e).getCode());
     }
-    assertThat(expectedException, is(true));
   }
 
   @Test
@@ -269,12 +265,12 @@ public class JdbcPreparedStatementTest {
       ps.setNull(27, Types.VARCHAR);
 
       JdbcParameterMetaData pmd = ps.getParameterMetaData();
-      Assert.assertEquals(27, pmd.getParameterCount());
-      Assert.assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(14));
+      assertEquals(27, pmd.getParameterCount());
+      assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(14));
 
       ps.clearParameters();
       pmd = ps.getParameterMetaData();
-      Assert.assertEquals(27, pmd.getParameterCount());
+      assertEquals(27, pmd.getParameterCount());
     }
   }
 
@@ -301,13 +297,13 @@ public class JdbcPreparedStatementTest {
     try (JdbcPreparedStatement ps =
         new JdbcPreparedStatement(createMockConnection(connection), sql)) {
       ResultSetMetaData metadata = ps.getMetaData();
-      assertThat(metadata.getColumnCount(), is(equalTo(3)));
-      assertThat(metadata.getColumnLabel(1), is(equalTo("ID")));
-      assertThat(metadata.getColumnLabel(2), is(equalTo("NAME")));
-      assertThat(metadata.getColumnLabel(3), is(equalTo("AMOUNT")));
-      assertThat(metadata.getColumnType(1), is(equalTo(Types.BIGINT)));
-      assertThat(metadata.getColumnType(2), is(equalTo(Types.NVARCHAR)));
-      assertThat(metadata.getColumnType(3), is(equalTo(Types.DOUBLE)));
+      assertEquals(3, metadata.getColumnCount());
+      assertEquals("ID", metadata.getColumnLabel(1));
+      assertEquals("NAME", metadata.getColumnLabel(2));
+      assertEquals("AMOUNT", metadata.getColumnLabel(3));
+      assertEquals(Types.BIGINT, metadata.getColumnType(1));
+      assertEquals(Types.NVARCHAR, metadata.getColumnType(2));
+      assertEquals(Types.DOUBLE, metadata.getColumnType(3));
     }
   }
 }

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.spanner.jdbc.it;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 
 import com.google.api.client.util.Base64;
 import com.google.cloud.spanner.IntegrationTest;
@@ -47,7 +47,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Scanner;
 import java.util.TimeZone;
-import org.junit.BeforeClass;
+import java.util.UUID;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -257,11 +257,6 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
     return res;
   }
 
-  @BeforeClass
-  public static void notOnEmulator() {
-    assumeFalse("foreign keys are not supported on the emulator", env.getTestHelper().isEmulator());
-  }
-
   @Override
   protected boolean doCreateMusicTables() {
     return true;
@@ -289,7 +284,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         }
         int[] results = ps.executeBatch();
         for (int res : results) {
-          assertThat(res, is(equalTo(1)));
+          assertEquals(1, res);
         }
       }
       try (PreparedStatement ps =
@@ -302,7 +297,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           ps.setString(3, album.albumTitle);
           ps.setLong(4, album.marketingBudget);
           assertInsertAlbumParameterMetadata(ps.getParameterMetaData());
-          assertThat(ps.executeUpdate(), is(equalTo(1)));
+          assertEquals(1, ps.executeUpdate());
           // check that calling executeUpdate will not reset the meta data
           assertInsertAlbumParameterMetadata(ps.getParameterMetaData());
         }
@@ -319,7 +314,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           ps.setLong(5, song.duration);
           ps.setCharacterStream(6, new StringReader(song.songGenre));
           assertInsertSongParameterMetadata(ps.getParameterMetaData());
-          assertThat(ps.executeUpdate(), is(equalTo(1)));
+          assertEquals(1, ps.executeUpdate());
           // check that calling executeUpdate will not reset the meta data
           assertInsertSongParameterMetadata(ps.getParameterMetaData());
         }
@@ -336,7 +331,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           ps.setTimestamp(5, concert.endTime);
           ps.setArray(6, connection.createArrayOf("INT64", concert.ticketPrices));
           assertInsertConcertParameterMetadata(ps.getParameterMetaData());
-          assertThat(ps.executeUpdate(), is(equalTo(1)));
+          assertEquals(1, ps.executeUpdate());
           // check that calling executeUpdate will not reset the meta data
           assertInsertConcertParameterMetadata(ps.getParameterMetaData());
         }
@@ -350,26 +345,26 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
     try (Connection connection = createConnection()) {
       try (ResultSet rs =
           connection.createStatement().executeQuery("SELECT COUNT(*) FROM Singers")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(equalTo(30)));
-        assertThat(rs.next(), is(false));
+        assertTrue(rs.next());
+        assertEquals(30, rs.getInt(1));
+        assertFalse(rs.next());
       }
       try (ResultSet rs =
           connection.createStatement().executeQuery("SELECT COUNT(*) FROM Albums")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getByte(1), is(equalTo((byte) 60)));
-        assertThat(rs.next(), is(false));
+        assertTrue(rs.next());
+        assertEquals(60, rs.getByte(1));
+        assertFalse(rs.next());
       }
       try (ResultSet rs = connection.createStatement().executeQuery("SELECT COUNT(*) FROM Songs")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getShort(1), is(equalTo((short) 149)));
-        assertThat(rs.next(), is(false));
+        assertTrue(rs.next());
+        assertEquals(149, rs.getShort(1));
+        assertFalse(rs.next());
       }
       try (ResultSet rs =
           connection.createStatement().executeQuery("SELECT COUNT(*) FROM Concerts")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getLong(1), is(equalTo(100L)));
-        assertThat(rs.next(), is(false));
+        assertTrue(rs.next());
+        assertEquals(100L, rs.getLong(1));
+        assertFalse(rs.next());
       }
       try (PreparedStatement ps =
           connection.prepareStatement("SELECT * FROM Concerts WHERE VenueId=? AND SingerId=?")) {
@@ -379,13 +374,13 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         // (1,1,DATE '2003-06-19',TIMESTAMP '2003-06-19T12:30:05Z',TIMESTAMP
         // '2003-06-19T18:57:15Z',[11,93,140,923]);
         try (ResultSet rs = ps.executeQuery()) {
-          assertThat(rs.next(), is(true));
-          assertThat(rs.getLong(1), is(equalTo(1L)));
-          assertThat(rs.getLong(2), is(equalTo(1L)));
-          assertThat(rs.getDate(3), is(equalTo(Date.valueOf("2003-06-19"))));
-          assertThat(rs.getTimestamp(4), is(equalTo(Timestamp.valueOf("2003-06-19 12:30:05"))));
-          assertThat(rs.getTimestamp(5), is(equalTo(Timestamp.valueOf("2003-06-19 18:57:15"))));
-          assertThat(((Long[]) rs.getArray(6).getArray())[0], is(equalTo(11L)));
+          assertTrue(rs.next());
+          assertEquals(1L, rs.getLong(1));
+          assertEquals(1L, rs.getLong(2));
+          assertEquals(Date.valueOf("2003-06-19"), rs.getDate(3));
+          assertEquals(Timestamp.valueOf("2003-06-19 12:30:05"), rs.getTimestamp(4));
+          assertEquals(Timestamp.valueOf("2003-06-19 18:57:15"), rs.getTimestamp(5));
+          assertArrayEquals(new Long[] {11L, 93L, 140L, 923L}, (Long[]) rs.getArray(6).getArray());
         }
       }
     }
@@ -461,9 +456,9 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
             ps.setLong(1, 100L);
             ps.setLong(2, 19L);
             try (ResultSet rs = ps.executeQuery()) {
-              assertThat(rs.next(), is(true));
+              assertTrue(rs.next());
               if (testCalendar == null) {
-                assertThat(rs.getDate(3), is(equalTo(Date.valueOf(expectedValues.get(index)))));
+                assertEquals(Date.valueOf(expectedValues.get(index)), rs.getDate(3));
               } else {
                 // Parse the date in the local timezone.
                 Date date = Date.valueOf(expectedValues.get(index));
@@ -473,9 +468,8 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
                 localCalendar.set(date.getYear() + 1900, date.getMonth(), date.getDate());
                 // Check that the actual time of the date returned by the ResultSet is equal to the
                 // local time in the timezone of the Calendar that is used.
-                assertThat(
-                    rs.getDate(3, testCalendar),
-                    is(equalTo(new Date(localCalendar.getTimeInMillis()))));
+                assertEquals(
+                    new Date(localCalendar.getTimeInMillis()), rs.getDate(3, testCalendar));
               }
             }
           }
@@ -567,38 +561,34 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
             ps.setLong(1, 100L);
             ps.setLong(2, 19L);
             try (ResultSet rs = ps.executeQuery()) {
-              assertThat(rs.next(), is(true));
+              assertTrue(rs.next());
 
               // First test the timestamp that was sent to Spanner using the default timezone.
               // Get the timestamp in the default timezone.
               Timestamp inDefaultTZ = rs.getTimestamp(4);
-              assertThat(inDefaultTZ.getTime(), is(equalTo(testTimestamp.getTime())));
+              assertEquals(testTimestamp.getTime(), inDefaultTZ.getTime());
               // Then get it in the test timezone.
               if (testCalendar != null) {
                 Timestamp inOtherTZ = rs.getTimestamp(4, testCalendar);
-                assertThat(
-                    inOtherTZ.getTime(),
-                    is(
-                        equalTo(
-                            testTimestamp.getTime() + testCalendar.getTimeZone().getRawOffset())));
+                assertEquals(
+                    testTimestamp.getTime() + testCalendar.getTimeZone().getRawOffset(),
+                    inOtherTZ.getTime());
               }
 
               // Then test the timestamp that was sent to Spanner using a specific timezone.
               // Get the timestamp in the default timezone.
               inDefaultTZ = rs.getTimestamp(5);
               if (testCalendar == null) {
-                assertThat(inDefaultTZ.getTime(), is(equalTo(testTimestamp.getTime())));
+                assertEquals(testTimestamp.getTime(), inDefaultTZ.getTime());
               } else {
-                assertThat(
-                    inDefaultTZ.getTime(),
-                    is(
-                        equalTo(
-                            testTimestamp.getTime() - testCalendar.getTimeZone().getRawOffset())));
+                assertEquals(
+                    testTimestamp.getTime() - testCalendar.getTimeZone().getRawOffset(),
+                    inDefaultTZ.getTime());
               }
               // Then get it in the test timezone.
               if (testCalendar != null) {
                 Timestamp inOtherTZ = rs.getTimestamp(5, testCalendar);
-                assertThat(inOtherTZ.getTime(), is(equalTo(testTimestamp.getTime())));
+                assertEquals(testTimestamp.getTime(), inOtherTZ.getTime());
               }
             }
           }
@@ -626,15 +616,15 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           }
           updateCounts = ps.executeBatch();
         }
-        assertThat(updateCounts.length, is(equalTo(params.length)));
+        assertEquals(params.length, updateCounts.length);
         long totalUpdated = 0;
         try (PreparedStatement ps =
             con1.prepareStatement("SELECT COUNT(*) FROM Singers WHERE LastName LIKE ?")) {
           for (int i = 0; i < updateCounts.length; i++) {
             ps.setString(1, params[i]);
             try (ResultSet rs = ps.executeQuery()) {
-              assertThat(rs.next(), is(true));
-              assertThat(updateCounts[i], is(equalTo(rs.getInt(1))));
+              assertTrue(rs.next());
+              assertEquals(rs.getInt(1), updateCounts[i]);
               totalUpdated += updateCounts[i];
             }
           }
@@ -643,11 +633,11 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         try (ResultSet rs =
             con2.createStatement()
                 .executeQuery("SELECT COUNT(*) FROM Singers WHERE FirstName=LastName")) {
-          assertThat(rs.next(), is(true));
+          assertTrue(rs.next());
           if (autocommit) {
-            assertThat(rs.getLong(1), is(equalTo(totalUpdated)));
+            assertEquals(totalUpdated, rs.getLong(1));
           } else {
-            assertThat(rs.getLong(1), is(equalTo(0L)));
+            assertEquals(0, rs.getLong(1));
           }
         }
         // If not in autocommit mode --> commit and verify.
@@ -656,15 +646,15 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           try (ResultSet rs =
               con2.createStatement()
                   .executeQuery("SELECT COUNT(*) FROM Singers WHERE FirstName=LastName")) {
-            assertThat(rs.next(), is(true));
-            assertThat(rs.getLong(1), is(equalTo(totalUpdated)));
+            assertTrue(rs.next());
+            assertEquals(totalUpdated, rs.getLong(1));
           }
         }
         // Set first names to null for the updated records for the next test run.
-        assertThat(
+        int updateCount =
             con2.createStatement()
-                .executeUpdate("UPDATE Singers SET FirstName=null WHERE FirstName=LastName"),
-            is(equalTo((int) totalUpdated)));
+                .executeUpdate("UPDATE Singers SET FirstName=null WHERE FirstName=LastName");
+        assertEquals(totalUpdated, updateCount);
       }
     }
   }
@@ -688,7 +678,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           ps.executeBatch();
           fail("missing expected BatchUpdateException");
         } catch (BatchUpdateException e) {
-          assertThat(e.getUpdateCounts().length, is(equalTo(2)));
+          assertEquals(2, e.getUpdateCounts().length);
         }
         // If not in autocommit mode --> rollback before the next run.
         if (!autocommit) {
@@ -719,7 +709,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         statement.executeBatch();
         fail("missing expected BatchUpdateException");
       } catch (BatchUpdateException e) {
-        assertThat(e.getUpdateCounts(), is(notNullValue()));
+        assertNotNull(e.getUpdateCounts());
       }
       // The following statements will fail because the table does not exist.
       try (Statement statement = con.createStatement()) {
@@ -734,7 +724,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         statement.executeBatch();
         fail();
       } catch (BatchUpdateException e) {
-        assertThat(e.getUpdateCounts(), is(notNullValue()));
+        assertNotNull(e.getUpdateCounts());
       }
       // The following statements will fail because the primary key values conflict.
       try (Statement statement = con.createStatement()) {
@@ -745,7 +735,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         statement.executeBatch();
         fail();
       } catch (BatchUpdateException e) {
-        assertThat(e.getUpdateCounts(), is(notNullValue()));
+        assertNotNull(e.getUpdateCounts());
       }
     }
   }
@@ -763,7 +753,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         ps.setDouble(2, 2D);
         ps.setBoolean(3, true);
         ps.setString(4, "test");
-        ps.setString(5, "testtest");
+        ps.setObject(5, UUID.fromString("2d37f522-e0a5-4f22-8e09-4d77d299c967"));
         ps.setBytes(6, "test".getBytes());
         ps.setBytes(7, "testtest".getBytes());
         ps.setDate(8, new Date(System.currentTimeMillis()));
@@ -797,59 +787,56 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
         ps.setArray(
             20,
             con.createArrayOf("NUMERIC", new BigDecimal[] {BigDecimal.ONE, null, BigDecimal.TEN}));
-        assertThat(ps.executeUpdate(), is(equalTo(1)));
+        assertEquals(1, ps.executeUpdate());
       }
       try (ResultSet rs =
           con.createStatement().executeQuery("SELECT * FROM TableWithAllColumnTypes")) {
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getLong(1), is(equalTo(1L)));
-        assertThat(rs.getDouble(2), is(equalTo(2D)));
-        assertThat(rs.getBoolean(3), is(true));
-        assertThat(rs.getString(4), is(equalTo("test")));
-        assertThat(rs.getString(5), is(equalTo("testtest")));
-        assertThat(rs.getBytes(6), is(equalTo("test".getBytes())));
-        assertThat(rs.getBytes(7), is(equalTo("testtest".getBytes())));
-        assertThat(rs.getDate(8), is(notNullValue()));
-        assertThat(rs.getTimestamp(9), is(notNullValue()));
-        assertThat(rs.getTime(10), is(notNullValue())); // Commit timestamp
-        assertThat(rs.getBigDecimal(11), is(equalTo(BigDecimal.TEN)));
-        assertThat((Long[]) rs.getArray(12).getArray(), is(equalTo(new Long[] {1L, 2L, 3L})));
-        assertThat(
-            (Double[]) rs.getArray(13).getArray(), is(equalTo(new Double[] {1.1D, 2.2D, 3.3D})));
-        assertThat(
-            (Boolean[]) rs.getArray(14).getArray(), is(equalTo(new Boolean[] {true, null, false})));
-        assertThat(
-            (String[]) rs.getArray(15).getArray(), is(equalTo(new String[] {"1", "2", "3"})));
-        assertThat(
-            (String[]) rs.getArray(16).getArray(), is(equalTo(new String[] {"3", "2", "1"})));
-        assertThat(
-            (byte[][]) rs.getArray(17).getArray(),
-            is(equalTo(new byte[][] {"1".getBytes(), "2".getBytes(), "3".getBytes()})));
-        assertThat(
-            (byte[][]) rs.getArray(18).getArray(),
-            is(equalTo(new byte[][] {"333".getBytes(), "222".getBytes(), "111".getBytes()})));
-        assertThat(((Date[]) rs.getArray(19).getArray()).length, is(equalTo(3)));
-        assertThat(((Timestamp[]) rs.getArray(20).getArray()).length, is(equalTo(3)));
-        assertThat(
-            (BigDecimal[]) rs.getArray(21).getArray(),
-            is(equalTo(new BigDecimal[] {BigDecimal.ONE, null, BigDecimal.TEN})));
-        assertThat(rs.next(), is(false));
+        assertTrue(rs.next());
+        assertEquals(1L, rs.getLong(1));
+        assertEquals(2d, rs.getDouble(2), 0.0d);
+        assertTrue(rs.getBoolean(3));
+        assertEquals("test", rs.getString(4));
+        assertEquals("2d37f522-e0a5-4f22-8e09-4d77d299c967", rs.getString(5));
+        assertArrayEquals("test".getBytes(), rs.getBytes(6));
+        assertArrayEquals("testtest".getBytes(), rs.getBytes(7));
+        assertNotNull(rs.getDate(8));
+        assertNotNull(rs.getTimestamp(9));
+        assertNotNull(rs.getTime(10)); // Commit timestamp
+        assertEquals(BigDecimal.TEN, rs.getBigDecimal(11));
+        assertArrayEquals(new Long[] {1L, 2L, 3L}, (Long[]) rs.getArray(12).getArray());
+        assertArrayEquals(new Double[] {1.1D, 2.2D, 3.3D}, (Double[]) rs.getArray(13).getArray());
+        assertArrayEquals(
+            new Boolean[] {true, null, false}, (Boolean[]) rs.getArray(14).getArray());
+        assertArrayEquals(new String[] {"1", "2", "3"}, (String[]) rs.getArray(15).getArray());
+        assertArrayEquals(new String[] {"3", "2", "1"}, (String[]) rs.getArray(16).getArray());
+        assertArrayEquals(
+            new byte[][] {"1".getBytes(), "2".getBytes(), "3".getBytes()},
+            (byte[][]) rs.getArray(17).getArray());
+        assertArrayEquals(
+            new byte[][] {"333".getBytes(), "222".getBytes(), "111".getBytes()},
+            (byte[][]) rs.getArray(18).getArray());
+        assertEquals(3, ((Date[]) rs.getArray(19).getArray()).length);
+        assertEquals(3, ((Timestamp[]) rs.getArray(20).getArray()).length);
+        assertArrayEquals(
+            new BigDecimal[] {BigDecimal.ONE, null, BigDecimal.TEN},
+            (BigDecimal[]) rs.getArray(21).getArray());
+        assertFalse(rs.next());
       }
     }
   }
 
   private void assertDefaultParameterMetaData(ParameterMetaData pmd, int expectedParamCount)
       throws SQLException {
-    assertThat(pmd.getParameterCount(), is(equalTo(expectedParamCount)));
+    assertEquals(expectedParamCount, pmd.getParameterCount());
     for (int param = 1; param <= expectedParamCount; param++) {
-      assertThat(pmd.getParameterType(param), is(equalTo(Types.OTHER)));
-      assertThat(pmd.getParameterTypeName(param), is(equalTo("OTHER")));
-      assertThat(pmd.getPrecision(param), is(equalTo(0)));
-      assertThat(pmd.getScale(param), is(equalTo(0)));
-      assertThat(pmd.getParameterClassName(param), is(nullValue()));
-      assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-      assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-      assertThat(pmd.isSigned(param), is(false));
+      assertEquals(Types.OTHER, pmd.getParameterType(param));
+      assertEquals("OTHER", pmd.getParameterTypeName(param));
+      assertEquals(0, pmd.getPrecision(param));
+      assertEquals(0, pmd.getScale(param));
+      assertNull(pmd.getParameterClassName(param));
+      assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+      assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+      assertFalse(pmd.isSigned(param));
     }
   }
 
@@ -877,7 +864,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
   }
 
   private void assertInsertSingerParameterMetadata(ParameterMetaData pmd) throws SQLException {
-    assertThat(pmd.getParameterCount(), is(equalTo(5)));
+    assertEquals(5, pmd.getParameterCount());
     assertByteParam(pmd, 1);
     assertStringParam(pmd, 2);
     assertStringParam(pmd, 3);
@@ -886,7 +873,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
   }
 
   private void assertInsertAlbumParameterMetadata(ParameterMetaData pmd) throws SQLException {
-    assertThat(pmd.getParameterCount(), is(equalTo(4)));
+    assertEquals(4, pmd.getParameterCount());
     assertLongParam(pmd, 1);
     assertLongParam(pmd, 2);
     assertStringParam(pmd, 3);
@@ -894,7 +881,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
   }
 
   private void assertInsertSongParameterMetadata(ParameterMetaData pmd) throws SQLException {
-    assertThat(pmd.getParameterCount(), is(equalTo(6)));
+    assertEquals(6, pmd.getParameterCount());
     assertByteParam(pmd, 1);
     assertIntParam(pmd, 2);
     assertShortParam(pmd, 3);
@@ -904,7 +891,7 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
   }
 
   private void assertInsertConcertParameterMetadata(ParameterMetaData pmd) throws SQLException {
-    assertThat(pmd.getParameterCount(), is(equalTo(6)));
+    assertEquals(6, pmd.getParameterCount());
     assertLongParam(pmd, 1);
     assertLongParam(pmd, 2);
     assertDateParam(pmd, 3);
@@ -914,124 +901,101 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
   }
 
   private void assertLongParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.BIGINT)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("INT64")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Long.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(true));
+    assertEquals(Types.BIGINT, pmd.getParameterType(param));
+    assertInt64Param(pmd, param, Long.class);
   }
 
   private void assertIntParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.INTEGER)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("INT64")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Integer.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(true));
+    assertEquals(Types.INTEGER, pmd.getParameterType(param));
+    assertInt64Param(pmd, param, Integer.class);
   }
 
   private void assertShortParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.SMALLINT)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("INT64")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Short.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(true));
+    assertEquals(Types.SMALLINT, pmd.getParameterType(param));
+    assertInt64Param(pmd, param, Short.class);
   }
 
   private void assertByteParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.TINYINT)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("INT64")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Byte.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(true));
+    assertEquals(Types.TINYINT, pmd.getParameterType(param));
+    assertInt64Param(pmd, param, Byte.class);
+  }
+
+  private void assertInt64Param(ParameterMetaData pmd, int param, Class<?> paramClass)
+      throws SQLException {
+    assertEquals("INT64", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals(paramClass.getName(), pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertTrue(pmd.isSigned(param));
   }
 
   private void assertStringParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.NVARCHAR)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("STRING")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(String.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertStringParam(pmd, param, String.class);
+  }
+
+  private void assertStringParam(ParameterMetaData pmd, int param, Class<?> paramClass)
+      throws SQLException {
+    assertEquals(Types.NVARCHAR, pmd.getParameterType(param));
+    assertEquals("STRING", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals(paramClass.getName(), pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertFalse(pmd.isSigned(param));
   }
 
   private void assertNStringParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.NVARCHAR)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("STRING")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(String.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertStringParam(pmd, param);
   }
 
   private void assertStringReaderParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.NVARCHAR)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("STRING")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(StringReader.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertStringParam(pmd, param, StringReader.class);
   }
 
   private void assertBytesParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.BINARY)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("BYTES")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(byte[].class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertEquals(Types.BINARY, pmd.getParameterType(param));
+    assertEquals("BYTES", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals(byte[].class.getName(), pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertFalse(pmd.isSigned(param));
   }
 
   private void assertDateParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.DATE)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("DATE")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Date.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertEquals(Types.DATE, pmd.getParameterType(param));
+    assertEquals("DATE", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals(Date.class.getName(), pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertFalse(pmd.isSigned(param));
   }
 
   private void assertTimestampParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.TIMESTAMP)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("TIMESTAMP")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(pmd.getParameterClassName(param), is(equalTo(Timestamp.class.getName())));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertEquals(Types.TIMESTAMP, pmd.getParameterType(param));
+    assertEquals("TIMESTAMP", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertFalse(pmd.isSigned(param));
   }
 
   private void assertLongArrayParam(ParameterMetaData pmd, int param) throws SQLException {
-    assertThat(pmd.getParameterType(param), is(equalTo(Types.ARRAY)));
-    assertThat(pmd.getParameterTypeName(param), is(equalTo("ARRAY")));
-    assertThat(pmd.getPrecision(param), is(equalTo(0)));
-    assertThat(pmd.getScale(param), is(equalTo(0)));
-    assertThat(
-        pmd.getParameterClassName(param), is(equalTo("com.google.cloud.spanner.jdbc.JdbcArray")));
-    assertThat(pmd.getParameterMode(param), is(equalTo(ParameterMetaData.parameterModeIn)));
-    assertThat(pmd.isNullable(param), is(equalTo(ParameterMetaData.parameterNullableUnknown)));
-    assertThat(pmd.isSigned(param), is(false));
+    assertEquals(Types.ARRAY, pmd.getParameterType(param));
+    assertEquals("ARRAY", pmd.getParameterTypeName(param));
+    assertEquals(0, pmd.getPrecision(param));
+    assertEquals(0, pmd.getScale(param));
+    assertEquals("com.google.cloud.spanner.jdbc.JdbcArray", pmd.getParameterClassName(param));
+    assertEquals(ParameterMetaData.parameterModeIn, pmd.getParameterMode(param));
+    assertEquals(ParameterMetaData.parameterNullableUnknown, pmd.isNullable(param));
+    assertFalse(pmd.isSigned(param));
   }
 }


### PR DESCRIPTION
Enables the usage of UUIDs as a parameter in PreparedStatements. UUIDs are automatically translated to strings.

Fixes #364
