### PR TITLE
feat!: upgrade to Java 8 and JDBC 4.2

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -34,7 +34,6 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
-    - "units (7)"
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [7, 8, 11]
+        java: [8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/.kokoro/nightly/java7.cfg
+++ b/.kokoro/nightly/java7.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java7"
-}

--- a/.kokoro/presubmit/java7.cfg
+++ b/.kokoro/presubmit/java7.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java7"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+          <compilerArgument>-Xlint:deprecation</compilerArgument>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludedGroups>com.google.cloud.spanner.IntegrationTest</excludedGroups>

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -31,6 +31,7 @@ import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -319,6 +320,21 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
       throws SQLException {
     checkClosed();
     parameters.setParameter(parameterIndex, value, targetSqlType, scaleOrLength);
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object value, SQLType targetSqlType)
+      throws SQLException {
+    checkClosed();
+    parameters.setParameter(parameterIndex, value, targetSqlType.getVendorTypeNumber());
+  }
+
+  @Override
+  public void setObject(int parameterIndex, Object value, SQLType targetSqlType, int scaleOrLength)
+      throws SQLException {
+    checkClosed();
+    parameters.setParameter(
+        parameterIndex, value, targetSqlType.getVendorTypeNumber(), scaleOrLength);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcResultSet.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcResultSet.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Time;
@@ -234,7 +235,18 @@ abstract class AbstractJdbcResultSet extends AbstractJdbcWrapper implements Resu
   }
 
   @Override
+  public void updateObject(int columnIndex, Object x, SQLType type, int scaleOrLength)
+      throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
   public void updateObject(int columnIndex, Object x) throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public void updateObject(int columnIndex, Object x, SQLType type) throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 
@@ -332,6 +344,17 @@ abstract class AbstractJdbcResultSet extends AbstractJdbcWrapper implements Resu
 
   @Override
   public void updateObject(String columnLabel, Object x) throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x, SQLType type) throws SQLException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public void updateObject(String columnLabel, Object x, SQLType type, int scaleOrLength)
+      throws SQLException {
     throw new SQLFeatureNotSupportedException();
   }
 

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
@@ -66,7 +66,8 @@ abstract class AbstractJdbcWrapper implements Wrapper {
     if (sqlType == Types.NUMERIC || sqlType == Types.DECIMAL)
       return Type.numeric().getCode().name();
     if (sqlType == Types.NVARCHAR) return Type.string().getCode().name();
-    if (sqlType == Types.TIMESTAMP) return Type.timestamp().getCode().name();
+    if (sqlType == Types.TIMESTAMP || sqlType == Types.TIMESTAMP_WITH_TIMEZONE)
+      return Type.timestamp().getCode().name();
     if (sqlType == Types.ARRAY) return Code.ARRAY.name();
 
     return OTHER_NAME;
@@ -84,7 +85,8 @@ abstract class AbstractJdbcWrapper implements Wrapper {
         || sqlType == Types.TINYINT) return Long.class.getName();
     if (sqlType == Types.NUMERIC || sqlType == Types.DECIMAL) return BigDecimal.class.getName();
     if (sqlType == Types.NVARCHAR) return String.class.getName();
-    if (sqlType == Types.TIMESTAMP) return Timestamp.class.getName();
+    if (sqlType == Types.TIMESTAMP || sqlType == Types.TIMESTAMP_WITH_TIMEZONE)
+      return Timestamp.class.getName();
     if (sqlType == Types.ARRAY) return Object.class.getName();
 
     return null;

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
@@ -1630,4 +1630,15 @@ class JdbcDatabaseMetaData extends AbstractJdbcWrapper implements DatabaseMetaDa
   public boolean generatedKeyAlwaysReturned() throws SQLException {
     return false;
   }
+
+  @Override
+  public long getMaxLogicalLobSize() throws SQLException {
+    // BYTES(MAX)
+    return 10485760L;
+  }
+
+  @Override
+  public boolean supportsRefCursors() throws SQLException {
+    return false;
+  }
 }

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -106,7 +106,8 @@ import java.util.regex.Pattern;
  */
 public class JdbcDriver implements Driver {
   private static final String JDBC_API_CLIENT_LIB_TOKEN = "sp-jdbc";
-  static final int MAJOR_VERSION = 1;
+  // Updated to version 2 when upgraded to Java 8 (JDBC 4.2)
+  static final int MAJOR_VERSION = 2;
   static final int MINOR_VERSION = 0;
   private static final String JDBC_URL_FORMAT =
       "jdbc:" + ConnectionOptions.Builder.SPANNER_URI_FORMAT;
@@ -245,13 +246,12 @@ public class JdbcDriver implements Driver {
 
   @Override
   public int getMajorVersion() {
-    // Updated to version 2 when upgraded to Java 8 (JDBC 4.2)
-    return 2;
+    return MAJOR_VERSION;
   }
 
   @Override
   public int getMinorVersion() {
-    return 0;
+    return MINOR_VERSION;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -245,7 +245,8 @@ public class JdbcDriver implements Driver {
 
   @Override
   public int getMajorVersion() {
-    return 1;
+    // Updated to version 2 when upgraded to Java 8 (JDBC 4.2)
+    return 2;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
@@ -204,7 +204,9 @@ class JdbcParameterStore {
       case Types.LONGNVARCHAR:
       case Types.DATE:
       case Types.TIME:
+      case Types.TIME_WITH_TIMEZONE:
       case Types.TIMESTAMP:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
       case Types.BINARY:
       case Types.VARBINARY:
       case Types.LONGVARBINARY:
@@ -249,7 +251,9 @@ class JdbcParameterStore {
             || value instanceof URL;
       case Types.DATE:
       case Types.TIME:
+      case Types.TIME_WITH_TIMEZONE:
       case Types.TIMESTAMP:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
         return value instanceof Date || value instanceof Time || value instanceof Timestamp;
       case Types.BINARY:
       case Types.VARBINARY:
@@ -522,7 +526,9 @@ class JdbcParameterStore {
         }
         throw JdbcSqlExceptionFactory.of(value + " is not a valid date", Code.INVALID_ARGUMENT);
       case Types.TIME:
+      case Types.TIME_WITH_TIMEZONE:
       case Types.TIMESTAMP:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
         if (value instanceof Date) {
           return binder.to(JdbcTypeConverter.toGoogleTimestamp((Date) value));
         } else if (value instanceof Time) {
@@ -715,7 +721,9 @@ class JdbcParameterStore {
         case Types.DATE:
           return binder.toDateArray((Iterable<com.google.cloud.Date>) null);
         case Types.TIME:
+        case Types.TIME_WITH_TIMEZONE:
         case Types.TIMESTAMP:
+        case Types.TIMESTAMP_WITH_TIMEZONE:
           return binder.toTimestampArray((Iterable<com.google.cloud.Timestamp>) null);
         case Types.BINARY:
         case Types.VARBINARY:
@@ -843,8 +851,9 @@ class JdbcParameterStore {
       case Types.SQLXML:
         return binder.to((String) null);
       case Types.TIME:
-        return binder.to((com.google.cloud.Timestamp) null);
+      case Types.TIME_WITH_TIMEZONE:
       case Types.TIMESTAMP:
+      case Types.TIMESTAMP_WITH_TIMEZONE:
         return binder.to((com.google.cloud.Timestamp) null);
       case Types.TINYINT:
         return binder.to((Long) null);

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatement.java
@@ -74,6 +74,11 @@ class JdbcPreparedStatement extends AbstractJdbcPreparedStatement {
     return executeUpdate(createStatement());
   }
 
+  public long executeLargeUpdate() throws SQLException {
+    checkClosed();
+    return executeLargeUpdate(createStatement());
+  }
+
   @Override
   public boolean execute() throws SQLException {
     checkClosed();

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcSqlExceptionFactory.java
@@ -127,6 +127,16 @@ public final class JdbcSqlExceptionFactory {
       this.code = Code.forNumber(cause.getCode());
     }
 
+    private JdbcSqlBatchUpdateException(long[] updateCounts, SpannerBatchUpdateException cause) {
+      super(
+          cause.getMessage(),
+          cause.getErrorCode().toString(),
+          cause.getCode(),
+          updateCounts,
+          cause);
+      this.code = Code.forNumber(cause.getCode());
+    }
+
     @Override
     public Code getCode() {
       return code;
@@ -313,6 +323,12 @@ public final class JdbcSqlExceptionFactory {
   /** Creates a {@link JdbcSqlException} for batch update exceptions. */
   static BatchUpdateException batchException(
       int[] updateCounts, SpannerBatchUpdateException cause) {
+    return new JdbcSqlBatchUpdateException(updateCounts, cause);
+  }
+
+  /** Creates a {@link JdbcSqlException} for large batch update exceptions. */
+  static BatchUpdateException batchException(
+      long[] updateCounts, SpannerBatchUpdateException cause) {
     return new JdbcSqlBatchUpdateException(updateCounts, cause);
   }
 }

--- a/src/test/java/com/google/cloud/spanner/jdbc/AbstractJdbcResultSetTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/AbstractJdbcResultSetTest.java
@@ -40,6 +40,7 @@ import java.sql.ResultSet;
 import java.sql.RowId;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
@@ -508,13 +509,6 @@ public class AbstractJdbcResultSetTest {
         new SqlRunnable() {
           @Override
           public void run() throws SQLException {
-            rs.updateObject("test", new Object());
-          }
-        });
-    assertUnsupported(
-        new SqlRunnable() {
-          @Override
-          public void run() throws SQLException {
             rs.updateObject(1, new Object(), 1);
           }
         });
@@ -522,7 +516,42 @@ public class AbstractJdbcResultSetTest {
         new SqlRunnable() {
           @Override
           public void run() throws SQLException {
+            rs.updateObject(1, new Object(), mock(SQLType.class));
+          }
+        });
+    assertUnsupported(
+        new SqlRunnable() {
+          @Override
+          public void run() throws SQLException {
+            rs.updateObject(1, new Object(), mock(SQLType.class), 0);
+          }
+        });
+    assertUnsupported(
+        new SqlRunnable() {
+          @Override
+          public void run() throws SQLException {
+            rs.updateObject("test", new Object());
+          }
+        });
+    assertUnsupported(
+        new SqlRunnable() {
+          @Override
+          public void run() throws SQLException {
             rs.updateObject("test", new Object(), 1);
+          }
+        });
+    assertUnsupported(
+        new SqlRunnable() {
+          @Override
+          public void run() throws SQLException {
+            rs.updateObject("test", new Object(), mock(SQLType.class));
+          }
+        });
+    assertUnsupported(
+        new SqlRunnable() {
+          @Override
+          public void run() throws SQLException {
+            rs.updateObject("test", new Object(), mock(SQLType.class), 1);
           }
         });
     assertUnsupported(

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -267,6 +269,8 @@ public class JdbcDatabaseMetaDataTest {
         }) {
       assertThat(meta.supportsTransactionIsolationLevel(level), is(false));
     }
+    assertEquals(10485760L, meta.getMaxLogicalLobSize());
+    assertFalse(meta.supportsRefCursors());
 
     // trivial tests that guarantee that the function works, but the return value doesn't matter
     assertThat(meta.getNumericFunctions(), is(notNullValue()));

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDriverTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDriverTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.jdbc;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.spanner.MockSpannerServiceImpl;
@@ -80,6 +81,12 @@ public class JdbcDriverTest {
   @Test
   public void testClientLibToken() {
     assertThat(JdbcDriver.getClientLibToken()).isEqualTo("sp-jdbc");
+  }
+
+  @Test
+  public void testVersion() throws SQLException {
+    assertEquals(JdbcDriver.MAJOR_VERSION, JdbcDriver.getRegisteredDriver().getMajorVersion());
+    assertEquals(JdbcDriver.MINOR_VERSION, JdbcDriver.getRegisteredDriver().getMinorVersion());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -192,7 +192,10 @@ public class JdbcParameterStoreTest {
     }
 
     // types that should lead to timestamp
-    for (int type : new int[] {Types.TIME, Types.TIMESTAMP}) {
+    for (int type :
+        new int[] {
+          Types.TIME, Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE
+        }) {
       params.setParameter(1, new Date(0L), type);
       assertEquals(new Date(0L), params.getParameter(1));
       verifyParameter(

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -86,7 +86,15 @@ public class JdbcParameterStoreTest {
     assertEquals(new Time(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
+    params.setParameter(1, new Time(0L), Types.TIME_WITH_TIMEZONE);
+    assertEquals(new Time(0L), params.getParameter(1));
+    verifyParameter(
+        params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
     params.setParameter(1, new Timestamp(0L), Types.TIMESTAMP);
+    assertEquals(new Timestamp(0L), params.getParameter(1));
+    verifyParameter(
+        params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
+    params.setParameter(1, new Timestamp(0L), Types.TIMESTAMP_WITH_TIMEZONE);
     assertEquals(new Timestamp(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
@@ -321,7 +329,10 @@ public class JdbcParameterStoreTest {
     }
 
     // types that should lead to timestamp
-    for (int type : new int[] {Types.TIME, Types.TIMESTAMP}) {
+    for (int type :
+        new int[] {
+          Types.TIME, Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE
+        }) {
       assertInvalidParameter(params, "1", type);
       assertInvalidParameter(params, new Object(), type);
       assertInvalidParameter(params, Boolean.TRUE, type);

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
@@ -39,6 +39,7 @@ import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Date;
+import java.sql.JDBCType;
 import java.sql.PreparedStatement;
 import java.sql.Ref;
 import java.sql.ResultSetMetaData;
@@ -101,7 +102,7 @@ public class JdbcPreparedStatementTest {
   @SuppressWarnings("deprecation")
   @Test
   public void testParameters() throws SQLException, MalformedURLException {
-    final int numberOfParams = 48;
+    final int numberOfParams = 51;
     String sql = generateSqlWithParameters(numberOfParams);
 
     JdbcConnection connection = createMockConnection();
@@ -151,6 +152,8 @@ public class JdbcPreparedStatementTest {
       ps.setUnicodeStream(47, new ByteArrayInputStream("TEST".getBytes()), 4);
       ps.setURL(48, new URL("https://spanner.google.com"));
       ps.setObject(49, UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"));
+      ps.setObject(50, "TEST", JDBCType.NVARCHAR);
+      ps.setObject(51, "TEST", JDBCType.NVARCHAR, 20);
 
       testSetUnsupportedTypes(ps);
 
@@ -204,6 +207,8 @@ public class JdbcPreparedStatementTest {
       assertEquals(ByteArrayInputStream.class.getName(), pmd.getParameterClassName(47));
       assertEquals(URL.class.getName(), pmd.getParameterClassName(48));
       assertEquals(UUID.class.getName(), pmd.getParameterClassName(49));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(50));
+      assertEquals(String.class.getName(), pmd.getParameterClassName(51));
 
       ps.clearParameters();
       pmd = ps.getParameterMetaData();

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
@@ -237,41 +237,46 @@ public class JdbcPreparedStatementTest {
 
   @Test
   public void testSetNullValues() throws SQLException {
-    String sql = generateSqlWithParameters(27);
+    final int numberOfParameters = 27;
+    String sql = generateSqlWithParameters(numberOfParameters);
     try (JdbcPreparedStatement ps = new JdbcPreparedStatement(createMockConnection(), sql)) {
-      ps.setNull(1, Types.BLOB);
-      ps.setNull(2, Types.NVARCHAR);
-      ps.setNull(4, Types.BINARY);
-      ps.setNull(5, Types.BOOLEAN);
-      ps.setNull(6, Types.TINYINT);
-      ps.setNull(7, Types.DATE);
-      ps.setNull(8, Types.DOUBLE);
-      ps.setNull(9, Types.FLOAT);
-      ps.setNull(10, Types.INTEGER);
-      ps.setNull(11, Types.BIGINT);
-      ps.setNull(12, Types.SMALLINT);
-      ps.setNull(13, Types.TIME);
-      ps.setNull(14, Types.TIMESTAMP);
-      ps.setNull(15, Types.CHAR);
-      ps.setNull(16, Types.CLOB);
-      ps.setNull(17, Types.LONGNVARCHAR);
-      ps.setNull(18, Types.LONGVARBINARY);
-      ps.setNull(19, Types.LONGVARCHAR);
-      ps.setNull(20, Types.NCHAR);
-      ps.setNull(21, Types.NCLOB);
-      ps.setNull(23, Types.NVARCHAR);
-      ps.setNull(24, Types.REAL);
-      ps.setNull(25, Types.BIT);
-      ps.setNull(26, Types.VARBINARY);
-      ps.setNull(27, Types.VARCHAR);
+      int index = 0;
+      ps.setNull(++index, Types.BLOB);
+      ps.setNull(++index, Types.NVARCHAR);
+      ps.setNull(++index, Types.BINARY);
+      ps.setNull(++index, Types.BOOLEAN);
+      ps.setNull(++index, Types.TINYINT);
+      ps.setNull(++index, Types.DATE);
+      ps.setNull(++index, Types.DOUBLE);
+      ps.setNull(++index, Types.FLOAT);
+      ps.setNull(++index, Types.INTEGER);
+      ps.setNull(++index, Types.BIGINT);
+      ps.setNull(++index, Types.SMALLINT);
+      ps.setNull(++index, Types.TIME);
+      ps.setNull(++index, Types.TIME_WITH_TIMEZONE);
+      ps.setNull(++index, Types.TIMESTAMP);
+      ps.setNull(++index, Types.TIMESTAMP_WITH_TIMEZONE);
+      ps.setNull(++index, Types.CHAR);
+      ps.setNull(++index, Types.CLOB);
+      ps.setNull(++index, Types.LONGNVARCHAR);
+      ps.setNull(++index, Types.LONGVARBINARY);
+      ps.setNull(++index, Types.LONGVARCHAR);
+      ps.setNull(++index, Types.NCHAR);
+      ps.setNull(++index, Types.NCLOB);
+      ps.setNull(++index, Types.NVARCHAR);
+      ps.setNull(++index, Types.REAL);
+      ps.setNull(++index, Types.BIT);
+      ps.setNull(++index, Types.VARBINARY);
+      ps.setNull(++index, Types.VARCHAR);
+      assertEquals(numberOfParameters, index);
 
       JdbcParameterMetaData pmd = ps.getParameterMetaData();
-      assertEquals(27, pmd.getParameterCount());
-      assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(14));
+      assertEquals(numberOfParameters, pmd.getParameterCount());
+      assertEquals(Timestamp.class.getName(), pmd.getParameterClassName(15));
 
       ps.clearParameters();
       pmd = ps.getParameterMetaData();
-      assertEquals(27, pmd.getParameterCount());
+      assertEquals(numberOfParameters, pmd.getParameterCount());
     }
   }
 

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementWithMockedServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementWithMockedServerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.jdbc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.MockSpannerServiceImpl;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.SpannerPool;
+import com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory.JdbcSqlBatchUpdateException;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JdbcPreparedStatementWithMockedServerTest {
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static InetSocketAddress address;
+
+  @Parameter public boolean executeLarge;
+
+  @Parameters(name = "executeLarge = {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {{false}, {true}});
+  }
+
+  @BeforeClass
+  public static void startStaticServer() throws IOException {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D);
+    address = new InetSocketAddress("localhost", 0);
+    server = NettyServerBuilder.forAddress(address).addService(mockSpanner).build().start();
+  }
+
+  @AfterClass
+  public static void stopServer() throws Exception {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @After
+  public void reset() {
+    SpannerPool.closeSpannerPool();
+    mockSpanner.removeAllExecutionTimes();
+    mockSpanner.reset();
+  }
+
+  private String createUrl() {
+    return String.format(
+        "jdbc:cloudspanner://localhost:%d/projects/%s/instances/%s/databases/%s?usePlainText=true",
+        server.getPort(), "proj", "inst", "db");
+  }
+
+  private Connection createConnection() throws SQLException {
+    return DriverManager.getConnection(createUrl());
+  }
+
+  @Test
+  public void testExecuteBatch() throws SQLException {
+    Statement.Builder insertBuilder =
+        Statement.newBuilder("INSERT INTO Test (Col1, Col2) VALUES (@p1, @p2)");
+    mockSpanner.putStatementResult(
+        StatementResult.update(
+            insertBuilder.bind("p1").to(1L).bind("p2").to("test 1").build(), 1L));
+    mockSpanner.putStatementResult(
+        StatementResult.update(
+            insertBuilder.bind("p1").to(2L).bind("p2").to("test 2").build(), 1L));
+    try (Connection connection = createConnection()) {
+      try (PreparedStatement statement =
+          connection.prepareStatement("INSERT INTO Test (Col1, Col2) VALUES (?, ?)")) {
+        statement.setLong(1, 1L);
+        statement.setString(2, "test 1");
+        statement.addBatch();
+        statement.setLong(1, 2L);
+        statement.setString(2, "test 2");
+        statement.addBatch();
+        if (executeLarge) {
+          assertThat(statement.executeLargeBatch()).asList().containsExactly(1L, 1L);
+        } else {
+          assertThat(statement.executeBatch()).asList().containsExactly(1, 1);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testExecuteBatch_withOverflow() throws SQLException {
+    Statement.Builder insertBuilder =
+        Statement.newBuilder("INSERT INTO Test (Col1, Col2) VALUES (@p1, @p2)");
+    mockSpanner.putStatementResult(
+        StatementResult.update(
+            insertBuilder.bind("p1").to(1L).bind("p2").to("test 1").build(), 1L));
+    mockSpanner.putStatementResult(
+        StatementResult.update(
+            insertBuilder.bind("p1").to(2L).bind("p2").to("test 2").build(),
+            Integer.MAX_VALUE + 1L));
+    try (Connection connection = createConnection()) {
+      try (PreparedStatement statement =
+          connection.prepareStatement("INSERT INTO Test (Col1, Col2) VALUES (?, ?)")) {
+        statement.setLong(1, 1L);
+        statement.setString(2, "test 1");
+        statement.addBatch();
+        statement.setLong(1, 2L);
+        statement.setString(2, "test 2");
+        statement.addBatch();
+        if (executeLarge) {
+          assertThat(statement.executeLargeBatch())
+              .asList()
+              .containsExactly(1L, Integer.MAX_VALUE + 1L);
+        } else {
+          try {
+            statement.executeBatch();
+            fail("missing expected OutOfRange exception");
+          } catch (SQLException e) {
+            assertTrue(e instanceof JdbcSqlException);
+            JdbcSqlException sqlException = (JdbcSqlException) e;
+            assertEquals(
+                ErrorCode.OUT_OF_RANGE.getGrpcStatusCode().value(), sqlException.getErrorCode());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testExecuteBatch_withException() throws SQLException {
+    Statement.Builder insertBuilder =
+        Statement.newBuilder("INSERT INTO Test (Col1, Col2) VALUES (@p1, @p2)");
+    mockSpanner.putStatementResult(
+        StatementResult.update(
+            insertBuilder.bind("p1").to(1L).bind("p2").to("test 1").build(), 1L));
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            insertBuilder.bind("p1").to(2L).bind("p2").to("test 2").build(),
+            Status.ALREADY_EXISTS.asRuntimeException()));
+    try (Connection connection = createConnection()) {
+      try (PreparedStatement statement =
+          connection.prepareStatement("INSERT INTO Test (Col1, Col2) VALUES (?, ?)")) {
+        statement.setLong(1, 1L);
+        statement.setString(2, "test 1");
+        statement.addBatch();
+        statement.setLong(1, 2L);
+        statement.setString(2, "test 2");
+        statement.addBatch();
+        try {
+          if (executeLarge) {
+            statement.executeLargeBatch();
+          } else {
+            statement.executeBatch();
+          }
+        } catch (JdbcSqlBatchUpdateException e) {
+          if (executeLarge) {
+            assertThat(e.getLargeUpdateCounts()).asList().containsExactly(1L);
+          } else {
+            assertThat(e.getUpdateCounts()).asList().containsExactly(1);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Upgrades the JDBC driver to Java 8 and implements new methods added in JDBC 4.2. JDBC version 4.2 is linked with Java 8.

Drops support for Java 7.

Fixes #396
