### PR TITLE
build: remove java7 as required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -34,7 +34,6 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
-    - "units (7)"
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"


### PR DESCRIPTION
Removes Java7 unit tests as a required check before a PR can be merged. This seems to be necessary before #397 can be merged.