### PR TITLE
chore: sets the min version of the repo as Java 8

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -5,8 +5,10 @@
   "client_documentation": "https://googleapis.dev/java/google-cloud-spanner-jdbc/latest/index.html",
   "release_level": "ga",
   "language": "java",
+  "min_java_version": 8,
   "repo": "googleapis/java-spanner-jdbc",
   "repo_short": "java-spanner-jdbc",
   "distribution_name": "com.google.cloud:google-cloud-spanner-jdbc",
   "codeowner_team": "@googleapis/api-spanner-java"
 }
+


### PR DESCRIPTION
This is used by autosynth to generate files such as the README.