### PR TITLE
chore: marks the branch 1.21.x as stable

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,7 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+branches:
+- branch: 1.21.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true
+

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -38,6 +38,35 @@ branchProtectionRules:
     - "units (11)"
     - "Kokoro - Test: Integration"
     - "cla/google"
+
+# Rules for master branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: 1.21.x
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
+
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins


### PR DESCRIPTION
Updates the github configuration to mark the branch 1.21.x as stable.