### PR TITLE
chore: java 7 cleanup and stable branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,7 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+branches:
+- branch: 1.21.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true
+

--- a/.kokoro/nightly/java7.cfg
+++ b/.kokoro/nightly/java7.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java7"
-}

--- a/.kokoro/presubmit/java7.cfg
+++ b/.kokoro/presubmit/java7.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java7"
-}


### PR DESCRIPTION
Removes unused java 7 ci files.
Marks branch 1.21.x as stable.