### PR TITLE
chore: marks branch 1.21.x as stable

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,7 @@
 releaseType: java-yoshi
 bumpMinorPreMajor: true
+branches:
+- branch: 1.21.x
+  releaseType: java-yoshi
+  bumpMinorPreMajor: true
+

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -39,8 +39,6 @@ branchProtectionRules:
     - "Kokoro - Test: Integration"
     - "cla/google"
 
-# Rules for master branch protection
-branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
 # Defaults to `master`
 - pattern: 1.21.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -60,6 +60,7 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
+    - "units (7)"
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"

--- a/synth.py
+++ b/synth.py
@@ -19,5 +19,8 @@ import synthtool.languages.java as java
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
 java.common_templates(excludes=[
-    'README.md'
+    'README.md',
+    
+    '.github/release-please.yml',
+    '.github/sync-repo-settings.yaml',
 ])


### PR DESCRIPTION
Marks branch 1.21.x as stable.
Fixes sync-repo-settings.yaml file (removes duplicated line).