### PR TITLE
fix: NPE was thrown when getting an array of structs from a ResultSet

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.jdbc;
 
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
 import java.math.BigDecimal;
@@ -252,6 +253,32 @@ enum JdbcDataType {
     @Override
     public Type getSpannerType() {
       return Type.timestamp();
+    }
+  },
+  STRUCT {
+    @Override
+    public int getSqlType() {
+      return Types.STRUCT;
+    }
+
+    @Override
+    public Class<Struct> getJavaClass() {
+      return Struct.class;
+    }
+
+    @Override
+    public Code getCode() {
+      return Code.STRUCT;
+    }
+
+    @Override
+    public List<Struct> getArrayElements(ResultSet rs, int columnIndex) {
+      return rs.getStructList(columnIndex);
+    }
+
+    @Override
+    public Type getSpannerType() {
+      return Type.struct();
     }
   };
 


### PR DESCRIPTION
A `NullPointerException` was thrown if a `ResultSet` contained an array of `Struct`s and the `getArray()` method was called on the column.

Fixes #444
