### PR TITLE
feat: allow get/set Spanner Value instances

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -198,7 +198,7 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
   @Override
   public void setObject(int parameterIndex, Object value) throws SQLException {
     checkClosed();
-    parameters.setParameter(parameterIndex, value, null);
+    parameters.setParameter(parameterIndex, value, (SQLType) null);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
@@ -150,17 +150,13 @@ class JdbcParameterStore {
     setParameter(parameterIndex, value, null, null, null, null);
   }
 
-  /**
-   * Sets a parameter value as the specified vendor-specific {@link SQLType}. Only {@link JsonType}
-   * is currently supported.
-   */
+  /** Sets a parameter value as the specified vendor-specific {@link SQLType}. */
   void setParameter(int parameterIndex, Object value, SQLType sqlType) throws SQLException {
     setParameter(parameterIndex, value, null, null, null, sqlType);
   }
 
   /**
    * Sets a parameter value as the specified vendor-specific {@link SQLType} with the specified
-   * scale or length. Only {@link JsonType} is currently supported, which does not have a variable
    * scale or length. This method is only here to support the {@link
    * PreparedStatement#setObject(int, Object, SQLType, int)} method.
    */
@@ -172,7 +168,6 @@ class JdbcParameterStore {
   /**
    * Sets a parameter value as the specified sql type. The type can be one of the constants in
    * {@link Types} or a vendor specific type code supplied by a vendor specific {@link SQLType}.
-   * Currently only {@link JsonType#VENDOR_TYPE_NUMBER} is supported for the latter.
    */
   void setParameter(int parameterIndex, Object value, Integer sqlType) throws SQLException {
     setParameter(parameterIndex, value, sqlType, null);
@@ -181,8 +176,7 @@ class JdbcParameterStore {
   /**
    * Sets a parameter value as the specified sql type with the specified scale or length. The type
    * can be one of the constants in {@link Types} or a vendor specific type code supplied by a
-   * vendor specific {@link SQLType}. Currently only {@link JsonType#VENDOR_TYPE_NUMBER} is
-   * supported for the latter.
+   * vendor specific {@link SQLType}.
    */
   void setParameter(int parameterIndex, Object value, Integer sqlType, Integer scaleOrLength)
       throws SQLException {
@@ -193,7 +187,6 @@ class JdbcParameterStore {
    * Sets a parameter value as the specified sql type with the specified scale or length. Any {@link
    * SQLType} instance will take precedence over sqlType. The type can be one of the constants in
    * {@link Types} or a vendor specific type code supplied by a vendor specific {@link SQLType}.
-   * Currently only {@link JsonType#VENDOR_TYPE_NUMBER} is supported for the latter.
    */
   void setParameter(
       int parameterIndex,

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatement.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.connection.StatementParser;
 import com.google.cloud.spanner.jdbc.JdbcParameterStore.ParametersInfo;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -48,7 +49,8 @@ class JdbcPreparedStatement extends AbstractJdbcPreparedStatement {
     return parameters;
   }
 
-  private Statement createStatement() throws SQLException {
+  @VisibleForTesting
+  Statement createStatement() throws SQLException {
     ParametersInfo paramInfo = getParametersInfo();
     Statement.Builder builder = Statement.newBuilder(paramInfo.sqlWithNamedParameters);
     for (int index = 1; index <= getParameters().getHighestIndex(); index++) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -44,6 +44,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,61 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class JdbcParameterStoreTest {
+
+  /**
+   * Tests setting a {@link Value} as a parameter value.
+   *
+   * @throws SQLException
+   */
+  @Test
+  public void testSetValueAsParameter() throws SQLException {
+    JdbcParameterStore params = new JdbcParameterStore();
+    params.setParameter(1, Value.bool(true));
+    verifyParameter(params, Value.bool(true));
+    params.setParameter(1, Value.bytes(ByteArray.copyFrom("test")));
+    verifyParameter(params, Value.bytes(ByteArray.copyFrom("test")));
+    params.setParameter(1, Value.date(com.google.cloud.Date.fromYearMonthDay(2021, 5, 3)));
+    verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(2021, 5, 3)));
+    params.setParameter(1, Value.float64(3.14d));
+    verifyParameter(params, Value.float64(3.14d));
+    params.setParameter(1, Value.int64(1L));
+    verifyParameter(params, Value.int64(1L));
+    params.setParameter(1, Value.numeric(BigDecimal.TEN));
+    verifyParameter(params, Value.numeric(BigDecimal.TEN));
+    params.setParameter(1, Value.string("test"));
+    verifyParameter(params, Value.string("test"));
+    params.setParameter(
+        1, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(9999L, 101)));
+    verifyParameter(
+        params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(9999L, 101)));
+
+    params.setParameter(1, Value.boolArray(new boolean[] {true, false}));
+    verifyParameter(params, Value.boolArray(new boolean[] {true, false}));
+    params.setParameter(1, Value.bytesArray(Collections.singleton(ByteArray.copyFrom("test"))));
+    verifyParameter(params, Value.bytesArray(Collections.singleton(ByteArray.copyFrom("test"))));
+    params.setParameter(
+        1,
+        Value.dateArray(Collections.singleton(com.google.cloud.Date.fromYearMonthDay(2021, 5, 3))));
+    verifyParameter(
+        params,
+        Value.dateArray(Collections.singleton(com.google.cloud.Date.fromYearMonthDay(2021, 5, 3))));
+    params.setParameter(1, Value.float64Array(Collections.singleton(3.14d)));
+    verifyParameter(params, Value.float64Array(Collections.singleton(3.14d)));
+    params.setParameter(1, Value.int64Array(Collections.singleton(1L)));
+    verifyParameter(params, Value.int64Array(Collections.singleton(1L)));
+    params.setParameter(1, Value.numericArray(Collections.singleton(BigDecimal.TEN)));
+    verifyParameter(params, Value.numericArray(Collections.singleton(BigDecimal.TEN)));
+    params.setParameter(1, Value.stringArray(Collections.singleton("test")));
+    verifyParameter(params, Value.stringArray(Collections.singleton("test")));
+    params.setParameter(
+        1,
+        Value.timestampArray(
+            Collections.singleton(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(9999L, 101))));
+    verifyParameter(
+        params,
+        Value.timestampArray(
+            Collections.singleton(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(9999L, 101))));
+  }
 
   /** Tests setting a parameter value together with a sql type */
   @SuppressWarnings("deprecation")
@@ -422,55 +478,55 @@ public class JdbcParameterStoreTest {
   @Test
   public void testSetParameterWithoutType() throws SQLException {
     JdbcParameterStore params = new JdbcParameterStore();
-    params.setParameter(1, (byte) 1, null);
+    params.setParameter(1, (byte) 1, (Integer) null);
     assertEquals(1, ((Byte) params.getParameter(1)).byteValue());
     verifyParameter(params, Value.int64(1));
-    params.setParameter(1, (short) 1, null);
+    params.setParameter(1, (short) 1, (Integer) null);
     assertEquals(1, ((Short) params.getParameter(1)).shortValue());
     verifyParameter(params, Value.int64(1));
-    params.setParameter(1, 1, null);
+    params.setParameter(1, 1, (Integer) null);
     assertEquals(1, ((Integer) params.getParameter(1)).intValue());
     verifyParameter(params, Value.int64(1));
-    params.setParameter(1, 1L, null);
+    params.setParameter(1, 1L, (Integer) null);
     assertEquals(1, ((Long) params.getParameter(1)).longValue());
     verifyParameter(params, Value.int64(1));
-    params.setParameter(1, (float) 1, null);
+    params.setParameter(1, (float) 1, (Integer) null);
     assertEquals(1.0f, ((Float) params.getParameter(1)).floatValue(), 0.0f);
     verifyParameter(params, Value.float64(1));
-    params.setParameter(1, (double) 1, null);
+    params.setParameter(1, (double) 1, (Integer) null);
     assertEquals(1.0d, ((Double) params.getParameter(1)).doubleValue(), 0.0d);
     verifyParameter(params, Value.float64(1));
-    params.setParameter(1, new Date(1970 - 1900, 0, 1), null);
+    params.setParameter(1, new Date(1970 - 1900, 0, 1), (Integer) null);
     assertEquals(new Date(1970 - 1900, 0, 1), params.getParameter(1));
     verifyParameter(params, Value.date(com.google.cloud.Date.fromYearMonthDay(1970, 1, 1)));
-    params.setParameter(1, new Time(0L), null);
+    params.setParameter(1, new Time(0L), (Integer) null);
     assertEquals(new Time(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
-    params.setParameter(1, new Timestamp(0L), null);
+    params.setParameter(1, new Timestamp(0L), (Integer) null);
     assertEquals(new Timestamp(0L), params.getParameter(1));
     verifyParameter(
         params, Value.timestamp(com.google.cloud.Timestamp.ofTimeSecondsAndNanos(0L, 0)));
-    params.setParameter(1, new byte[] {1, 2, 3}, null);
+    params.setParameter(1, new byte[] {1, 2, 3}, (Integer) null);
     assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
 
-    params.setParameter(1, new JdbcBlob(new byte[] {1, 2, 3}), null);
+    params.setParameter(1, new JdbcBlob(new byte[] {1, 2, 3}), (Integer) null);
     assertEquals(new JdbcBlob(new byte[] {1, 2, 3}), params.getParameter(1));
     verifyParameter(params, Value.bytes(ByteArray.copyFrom(new byte[] {1, 2, 3})));
-    params.setParameter(1, new JdbcClob("test"), null);
+    params.setParameter(1, new JdbcClob("test"), (Integer) null);
     assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
-    params.setParameter(1, true, null);
+    params.setParameter(1, true, (Integer) null);
     assertTrue((Boolean) params.getParameter(1));
     verifyParameter(params, Value.bool(true));
-    params.setParameter(1, "test", null);
+    params.setParameter(1, "test", (Integer) null);
     assertEquals("test", params.getParameter(1));
     verifyParameter(params, Value.string("test"));
-    params.setParameter(1, new JdbcClob("test"), null);
+    params.setParameter(1, new JdbcClob("test"), (Integer) null);
     assertEquals(new JdbcClob("test"), params.getParameter(1));
     verifyParameter(params, Value.string("test"));
-    params.setParameter(1, UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"), null);
+    params.setParameter(1, UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"), (Integer) null);
     assertEquals(UUID.fromString("83b988cf-1f4e-428a-be3d-cc712621942e"), params.getParameter(1));
     verifyParameter(params, Value.string("83b988cf-1f4e-428a-be3d-cc712621942e"));
   }

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcResultSetTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcResultSetTest.java
@@ -35,6 +35,7 @@ import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.StructField;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.jdbc.JdbcSqlExceptionFactory.JdbcSqlExceptionImpl;
 import com.google.rpc.Code;
 import java.io.IOException;
@@ -52,6 +53,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import org.junit.Test;
@@ -125,6 +127,28 @@ public class JdbcResultSetTest {
   private static final String STRING_COL_TIME = "STRING_COL_TIME";
   private static final int STRING_COLINDEX_TIME = 24;
   private static final String STRING_TIME_VALUE = "10:31:15";
+  private static final String NUMERIC_COL_NULL = "NUMERIC_COL_NULL";
+  private static final String NUMERIC_COL_NOT_NULL = "NUMERIC_COL_NOT_NULL";
+  private static final BigDecimal NUMERIC_VALUE = new BigDecimal("3.14");
+  private static final int NUMERIC_COLINDEX_NULL = 25;
+  private static final int NUMERIC_COLINDEX_NOTNULL = 26;
+
+  private static final String BOOL_ARRAY_COL = "BOOL_ARRAY";
+  private static final List<Boolean> BOOL_ARRAY_VALUE = Arrays.asList(true, null, false);
+  private static final String BYTES_ARRAY_COL = "BYTES_ARRAY";
+  private static final List<ByteArray> BYTES_ARRAY_VALUE = Arrays.asList(BYTES_VALUE, null);
+  private static final String DATE_ARRAY_COL = "DATE_ARRAY";
+  private static final List<Date> DATE_ARRAY_VALUE = Arrays.asList(DATE_VALUE, null);
+  private static final String FLOAT64_ARRAY_COL = "FLOAT64_ARRAY";
+  private static final List<Double> FLOAT64_ARRAY_VALUE = Arrays.asList(DOUBLE_VALUE, null);
+  private static final String INT64_ARRAY_COL = "INT64_ARRAY";
+  private static final List<Long> INT64_ARRAY_VALUE = Arrays.asList(LONG_VALUE, null);
+  private static final String NUMERIC_ARRAY_COL = "NUMERIC_ARRAY";
+  private static final List<BigDecimal> NUMERIC_ARRAY_VALUE = Arrays.asList(NUMERIC_VALUE, null);
+  private static final String STRING_ARRAY_COL = "STRING_ARRAY";
+  private static final List<String> STRING_ARRAY_VALUE = Arrays.asList(STRING_VALUE, null);
+  private static final String TIMESTAMP_ARRAY_COL = "TIMESTAMP_ARRAY";
+  private static final List<Timestamp> TIMESTAMP_ARRAY_VALUE = Arrays.asList(TIMESTAMP_VALUE, null);
 
   private JdbcResultSet subject;
 
@@ -154,7 +178,17 @@ public class JdbcResultSetTest {
             StructField.of(STRING_COL_NUMBER, Type.string()),
             StructField.of(STRING_COL_DATE, Type.string()),
             StructField.of(STRING_COL_TIMESTAMP, Type.string()),
-            StructField.of(STRING_COL_TIME, Type.string())),
+            StructField.of(STRING_COL_TIME, Type.string()),
+            StructField.of(NUMERIC_COL_NULL, Type.numeric()),
+            StructField.of(NUMERIC_COL_NOT_NULL, Type.numeric()),
+            StructField.of(BOOL_ARRAY_COL, Type.array(Type.bool())),
+            StructField.of(BYTES_ARRAY_COL, Type.array(Type.bytes())),
+            StructField.of(DATE_ARRAY_COL, Type.array(Type.date())),
+            StructField.of(FLOAT64_ARRAY_COL, Type.array(Type.float64())),
+            StructField.of(INT64_ARRAY_COL, Type.array(Type.int64())),
+            StructField.of(NUMERIC_ARRAY_COL, Type.array(Type.numeric())),
+            StructField.of(STRING_ARRAY_COL, Type.array(Type.string())),
+            StructField.of(TIMESTAMP_ARRAY_COL, Type.array(Type.timestamp()))),
         Arrays.asList(
             Struct.newBuilder()
                 .set(STRING_COL_NULL)
@@ -205,6 +239,26 @@ public class JdbcResultSetTest {
                 .to(STRING_TIMESTAMP_VALUE)
                 .set(STRING_COL_TIME)
                 .to(STRING_TIME_VALUE)
+                .set(NUMERIC_COL_NULL)
+                .to((BigDecimal) null)
+                .set(NUMERIC_COL_NOT_NULL)
+                .to(NUMERIC_VALUE)
+                .set(BOOL_ARRAY_COL)
+                .toBoolArray(BOOL_ARRAY_VALUE)
+                .set(BYTES_ARRAY_COL)
+                .toBytesArray(BYTES_ARRAY_VALUE)
+                .set(DATE_ARRAY_COL)
+                .toDateArray(DATE_ARRAY_VALUE)
+                .set(FLOAT64_ARRAY_COL)
+                .toFloat64Array(FLOAT64_ARRAY_VALUE)
+                .set(INT64_ARRAY_COL)
+                .toInt64Array(INT64_ARRAY_VALUE)
+                .set(NUMERIC_ARRAY_COL)
+                .toNumericArray(NUMERIC_ARRAY_VALUE)
+                .set(STRING_ARRAY_COL)
+                .toStringArray(STRING_ARRAY_VALUE)
+                .set(TIMESTAMP_ARRAY_COL)
+                .toTimestampArray(TIMESTAMP_ARRAY_VALUE)
                 .build()));
   }
 
@@ -835,7 +889,7 @@ public class JdbcResultSetTest {
   }
 
   @Test
-  public void testGetBigDecimalIndex() throws SQLException {
+  public void testGetBigDecimalFromDouble_usingIndex() throws SQLException {
     assertNotNull(subject.getBigDecimal(DOUBLE_COLINDEX_NOTNULL));
     assertEquals(BigDecimal.valueOf(DOUBLE_VALUE), subject.getBigDecimal(DOUBLE_COLINDEX_NOTNULL));
     assertFalse(subject.wasNull());
@@ -844,11 +898,29 @@ public class JdbcResultSetTest {
   }
 
   @Test
-  public void testGetBigDecimalLabel() throws SQLException {
+  public void testGetBigDecimalFromDouble_usingLabel() throws SQLException {
     assertNotNull(subject.getBigDecimal(DOUBLE_COL_NOT_NULL));
     assertEquals(BigDecimal.valueOf(DOUBLE_VALUE), subject.getBigDecimal(DOUBLE_COL_NOT_NULL));
     assertFalse(subject.wasNull());
     assertNull(subject.getBigDecimal(DOUBLE_COL_NULL));
+    assertTrue(subject.wasNull());
+  }
+
+  @Test
+  public void testGetBigDecimalIndex() throws SQLException {
+    assertNotNull(subject.getBigDecimal(NUMERIC_COLINDEX_NOTNULL));
+    assertEquals(NUMERIC_VALUE, subject.getBigDecimal(NUMERIC_COLINDEX_NOTNULL));
+    assertFalse(subject.wasNull());
+    assertNull(subject.getBigDecimal(NUMERIC_COLINDEX_NULL));
+    assertTrue(subject.wasNull());
+  }
+
+  @Test
+  public void testGetBigDecimalLabel() throws SQLException {
+    assertNotNull(subject.getBigDecimal(NUMERIC_COL_NOT_NULL));
+    assertEquals(NUMERIC_VALUE, subject.getBigDecimal(NUMERIC_COL_NOT_NULL));
+    assertFalse(subject.wasNull());
+    assertNull(subject.getBigDecimal(NUMERIC_COL_NULL));
     assertTrue(subject.wasNull());
   }
 
@@ -1617,5 +1689,39 @@ public class JdbcResultSetTest {
   @Test
   public void testGetHoldability() throws SQLException {
     assertEquals(java.sql.ResultSet.CLOSE_CURSORS_AT_COMMIT, subject.getHoldability());
+  }
+
+  @Test
+  public void testGetObjectAsValue() throws SQLException {
+    assertEquals(
+        Value.bool(BOOLEAN_VALUE), subject.getObject(BOOLEAN_COLINDEX_NOTNULL, Value.class));
+    assertEquals(Value.bytes(BYTES_VALUE), subject.getObject(BYTES_COLINDEX_NOTNULL, Value.class));
+    assertEquals(Value.date(DATE_VALUE), subject.getObject(DATE_COLINDEX_NOTNULL, Value.class));
+    assertEquals(
+        Value.float64(DOUBLE_VALUE), subject.getObject(DOUBLE_COLINDEX_NOTNULL, Value.class));
+    assertEquals(Value.int64(LONG_VALUE), subject.getObject(LONG_COLINDEX_NOTNULL, Value.class));
+    assertEquals(
+        Value.numeric(NUMERIC_VALUE), subject.getObject(NUMERIC_COLINDEX_NOTNULL, Value.class));
+    assertEquals(
+        Value.string(STRING_VALUE), subject.getObject(STRING_COLINDEX_NOTNULL, Value.class));
+    assertEquals(
+        Value.timestamp(TIMESTAMP_VALUE),
+        subject.getObject(TIMESTAMP_COLINDEX_NOTNULL, Value.class));
+
+    assertEquals(Value.boolArray(BOOL_ARRAY_VALUE), subject.getObject(BOOL_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.bytesArray(BYTES_ARRAY_VALUE), subject.getObject(BYTES_ARRAY_COL, Value.class));
+    assertEquals(Value.dateArray(DATE_ARRAY_VALUE), subject.getObject(DATE_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.float64Array(FLOAT64_ARRAY_VALUE), subject.getObject(FLOAT64_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.int64Array(INT64_ARRAY_VALUE), subject.getObject(INT64_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.numericArray(NUMERIC_ARRAY_VALUE), subject.getObject(NUMERIC_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.stringArray(STRING_ARRAY_VALUE), subject.getObject(STRING_ARRAY_COL, Value.class));
+    assertEquals(
+        Value.timestampArray(TIMESTAMP_ARRAY_VALUE),
+        subject.getObject(TIMESTAMP_ARRAY_COL, Value.class));
   }
 }


### PR DESCRIPTION
Adds support for getting a value from a `java.sql.ResultSet` as a `com.google.cloud.spanner.Value` instance, and for setting a parameter on a `java.sql.PreparedStatement` using a `com.google.cloud.spanner.Value` instance.

Fixes #452
