### PR TITLE
deps: update dependency com.google.cloud:google-cloud-spanner-bom to v6.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.5.0</version>
+        <version>6.6.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Updates to Spanner client 6.6.0 and adds tests for optimizer stats package.

Replaces #497
