### PR TITLE
fix: prevent relocating urls that start with com like /computeMetadata/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,26 +333,26 @@
             <configuration>
               <relocations>
                 <relocation>
-                  <pattern>com</pattern>
-                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.com</shadedPattern>
+                  <pattern>com.</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.com.</shadedPattern>
                   <excludes>
                     <exclude>com.google.cloud.spanner.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>
-                  <pattern>android</pattern>
-                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.android</shadedPattern>
+                  <pattern>android.</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.android.</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>io</pattern>
-                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.io</shadedPattern>
+                  <pattern>io.</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.io.</shadedPattern>
                   <excludes>
                     <exclude>io.grpc.netty.shaded.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>
-                  <pattern>org</pattern>
-                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.org</shadedPattern>
+                  <pattern>org.</pattern>
+                  <shadedPattern>com.google.cloud.spanner.jdbc.shaded.org.</shadedPattern>
                   <excludes>
                     <exclude>org.conscrypt.**</exclude>
                   </excludes>


### PR DESCRIPTION
Fixes #503 

In addition to original problem I have added an exception for all the Netty libraries since I have got errors on service provider which claims that netty libraries are not a subtype. 
