### PR TITLE
chore: fix the dependencies check build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,14 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-spanner-admin-database-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+    </dependency>
     <!-- TODO: Remove grpc-alts from here once it has been removed as a runtime dependency from java-spanner -->
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
The proto-google-cloud-spanner-admin-database-v1 and gax dependencies needed to be added explicitly for the build step to succeed.