### PR TITLE
chore: setup maven 3.8.1 for ci tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ jobs:
         java: [8, 11]
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}
@@ -23,6 +26,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8
@@ -37,6 +43,9 @@ jobs:
         java: [8, 11]
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}
@@ -46,6 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8
@@ -57,6 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8

--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -17,6 +17,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.8.1
       - uses: actions/setup-java@v1
         with:
           java-version: 8


### PR DESCRIPTION
There is a bug with the maven-flattened plugin and maven 3.8.2, which is causing an error on builds. The yoshi team will file a bug under the plugin, but for now we need to downgrade maven to < 3.8.2.