### PR TITLE
test(deps): update dependency org.mockito:mockito-core to v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <findbugs.version>3.0.2</findbugs.version>
     <threeten.version>1.4.4</threeten.version>
     <truth.version>1.1.3</truth.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>4.0.0</mockito.version>
     <hamcrest.version>2.2</hamcrest.version>
   </properties>
 


### PR DESCRIPTION
Bumps the Mockito version used by the JDBC driver to 4.0, as the Spanner Java client has now also been updated.

Replaces #638 

cc @lesv 