### PR TITLE
fix(java): include integration tests for native image testing   

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludedGroups>com.google.cloud.spanner.IntegrationTest</excludedGroups>
+          <exclude>com.google.cloud.spanner.IntegrationTest</exclude>
           <reportNameSuffix>sponge_log</reportNameSuffix>
         </configuration>
       </plugin>


### PR DESCRIPTION
Some background: 
We want to run integration tests and unit tests (ending in *ClientTest) with the native profile. For this purpose, we want to [ignore any exclusions ](https://github.com/googleapis/java-shared-config/blob/ac44ba11d2da2f649670867c520f90253a8a41ff/pom.xml#L807) that take place in other maven-surefire-plugin configurations within the java-shared-config pom or other child poms so that we can explicitly include these tests. However, using `excludedGroups` in java-spanner-jdbc causes the **overriding of the exclusion** to be ignored. This results in integration tests being skipped in native mode which leads to native-image testing to fail with the message: ` Test configuration file wasn't found. Make sure that test execution wasn't skipped.`

This change replaces the use of `excludedGroups` with `exclude`, which allows the the maven-surefire-plugin configuration for the `native` profile to take precedence when `mvn test -P native` is called. Manual testing with `mvn test` results in only unit tests being run, therefore showing no change in current behavior for standard Java. 

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-iam-admin/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #719  ☕️