### PR TITLE
deps: update dependency com.google.cloud:google-cloud-spanner-bom to v6.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.20.0</version>
+        <version>6.21.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -915,9 +915,16 @@ public class JdbcParameterStoreTest {
         parser.convertPositionalParametersToNamedParameters('?', "?\"\"\"?it\\\"?s\"\"\"?")
             .sqlWithNamedParameters);
 
-    assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s'?");
+    // PostgreSQL allows newlines inside string literals.
+    assertEquals(
+        "$1'?it\\'?s \n ?it\\'?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'?it\\'?s \n ?it\\'?s'?")
+            .sqlWithNamedParameters);
     assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s?");
-    assertUnclosedLiteral("?'''?it\\'?s \n ?it\\'?s'?");
+    assertEquals(
+        "$1'''?it\\'?s \n ?it\\'?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s \n ?it\\'?s'?")
+            .sqlWithNamedParameters);
 
     assertEquals(
         "select 1, $1, 'test?test', \"test?test\", foo.* from `foo` where col1=$2 and col2='test' and col3=$3 and col4='?' and col5=\"?\" and col6='?''?''?'",


### PR DESCRIPTION
Updates the Spanner client library dependency to 6.21.2 and fixes a test case that verified that a newline inside of a string literal would break the parser. This was however wrong, as PostgreSQL does allow string literals to contain unescaped newline characters.

Replaces #780 