### PR TITLE
test: fixed test case that reset entire mock server instead of only requests

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/PgNumericPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/PgNumericPreparedStatementTest.java
@@ -86,7 +86,7 @@ public class PgNumericPreparedStatementTest {
             "jdbc:cloudspanner://%s/projects/%s/instances/%s/databases/%s?usePlainText=true;dialect=POSTGRESQL",
             endpoint, PROJECT, INSTANCE, DATABASE);
     connection = DriverManager.getConnection(url);
-    mockSpanner.reset();
+    mockSpanner.clearRequests();
   }
 
   @After


### PR DESCRIPTION
The `PgNumericPreparedStatementTest` reset the entire mock server after each test, instead of only clearing the requests on the mock server. This would also clear all sessions on the mock server, which could cause a `Session not found` error to occur occasionally.

Fixes #754 