### PR TITLE
test: add pg_catalog as an expected schema

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPgDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPgDatabaseMetaDataTest.java
@@ -754,6 +754,10 @@ public class ITJdbcPgDatabaseMetaDataTest extends ITAbstractJdbcTest {
 
         assertTrue(rs.next());
         assertEquals(getDefaultCatalog(database), rs.getString("TABLE_CATALOG"));
+        assertEquals("pg_catalog", rs.getString("TABLE_SCHEM"));
+
+        assertTrue(rs.next());
+        assertEquals(getDefaultCatalog(database), rs.getString("TABLE_CATALOG"));
         assertEquals("public", rs.getString("TABLE_SCHEM"));
 
         assertTrue(rs.next());


### PR DESCRIPTION
Adds `pg_catalog` as an expected schema to the JDBC metadata tests.

Fixes #810
