### PR TITLE
test: fix assert for testConnectWithCredentialsAndOAuthToken

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDriverTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDriverTest.java
@@ -132,7 +132,7 @@ public class JdbcDriverTest {
                 server.getPort(), TEST_KEY_PATH, "some-token"))) {
       fail("missing expected exception");
     } catch (SQLException e) {
-      assertThat(e.getMessage()).contains("Cannot specify both credentials and an OAuth token");
+      assertThat(e.getMessage()).contains("Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token");
     }
   }
 


### PR DESCRIPTION
testConnectWithCredentialsAndOAuthToken test was failing with following error -
JdbcDriverTest.testConnectWithCredentialsAndOAuthToken:135 expected to contain: Cannot specify both credentials and an OAuth token
but was : INVALID_ARGUMENT: Specify only one of credentialsUrl, encodedCredentials, credentialsProvider and OAuth token.

Changing assertThat to account for this change. The exception message was changed as part of https://github.com/googleapis/java-spanner/pull/1869.