### PR TITLE
feat: call java_client:execute from executeUpdate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.25.5</version>
+        <version>6.26.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -114,6 +114,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
+      <version>6.26.0</version>
     </dependency>
     <!-- TODO: Remove grpc-alts from here once it has been removed as a runtime dependency from java-spanner -->
     <dependency>
@@ -155,6 +156,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-spanner-v1</artifactId>
+      <version>6.26.0</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -163,6 +165,7 @@
       <artifactId>google-cloud-spanner</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
+      <version>6.26.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/src/test/java/com/google/cloud/spanner/jdbc/PgNumericPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/PgNumericPreparedStatementTest.java
@@ -29,6 +29,10 @@ import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.ResultSetStats;
+import com.google.spanner.v1.StructType;
 import com.google.spanner.v1.Type;
 import com.google.spanner.v1.TypeAnnotationCode;
 import com.google.spanner.v1.TypeCode;
@@ -60,6 +64,11 @@ public class PgNumericPreparedStatementTest {
   private static InetSocketAddress address;
   private static Server server;
   private Connection connection;
+  private static final com.google.spanner.v1.ResultSet UPDATE1_RESULTSET =
+      com.google.spanner.v1.ResultSet.newBuilder()
+          .setStats(ResultSetStats.newBuilder().setRowCountExact(1))
+          .setMetadata(ResultSetMetadata.getDefaultInstance().toBuilder().setRowType(StructType.getDefaultInstance()))
+          .build();
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -260,22 +269,22 @@ public class PgNumericPreparedStatementTest {
 
   private void mockScalarUpdateWithParam(String value) {
     mockSpanner.putStatementResult(
-        StatementResult.update(
+        StatementResult.query(
             Statement.newBuilder(REWRITTEN_QUERY)
                 .bind("p1")
                 .to(com.google.cloud.spanner.Value.pgNumeric(value))
                 .build(),
-            1));
+            UPDATE1_RESULTSET));
   }
 
   private void mockArrayUpdateWithParam(Iterable<String> value) {
     mockSpanner.putStatementResult(
-        StatementResult.update(
+        StatementResult.query(
             Statement.newBuilder(REWRITTEN_QUERY)
                 .bind("p1")
                 .to(com.google.cloud.spanner.Value.pgNumericArray(value))
                 .build(),
-            1));
+            UPDATE1_RESULTSET));
   }
 
   private void assertRequestWithScalar(String value) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcDdlTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcDdlTest.java
@@ -21,9 +21,12 @@ import static org.junit.Assume.assumeFalse;
 import com.google.cloud.spanner.Database;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.ParallelIntegrationTest;
+import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.jdbc.JdbcSqlScriptVerifier;
 import com.google.cloud.spanner.testing.EmulatorSpannerHelper;
 import com.google.common.collect.ImmutableMap;
+import java.sql.Connection;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,5 +84,22 @@ public class ITJdbcDdlTest extends ITAbstractJdbcTest {
         new JdbcSqlScriptVerifier(new ITJdbcConnectionProvider(env, database));
     verifier.verifyStatementsInFile(
         dialect.executeQueriesFiles.get("TEST_DDL"), JdbcSqlScriptVerifier.class, false);
+  }
+
+  @Test
+  public void testExecuteUpdateDDL() throws Exception {
+    try(Connection connection = createConnection(env, database)) {
+      Statement stmt = connection.createStatement();
+      int rs = stmt.executeUpdate("CREATE TABLE Venues ("
+          + "  VenueId         INT64 NOT NULL,"
+          + "  VenueName       STRING(100),"
+          + "  Capacity        INT64,"
+          + "  LastContactDate DATE,"
+          + "  OutdoorVenue    BOOL, "
+          + "  PopularityScore FLOAT64, "
+          + "  Revenue         NUMERIC, "
+          + ") PRIMARY KEY (VenueId)");
+      System.out.println(rs);
+    }
   }
 }


### PR DESCRIPTION
Throw an exception if the query passed into executeUpdate returns a ResultSet. We call the java_client:execute API to check the actual result of the query, and then throw an exception if the returned value is a ResultSet.