### PR TITLE
test: modify tests to use correct quote escaping

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -895,35 +895,35 @@ public class JdbcParameterStoreTest {
         parser.convertPositionalParametersToNamedParameters('?', "?'?test?\"?test?\"?'?")
             .sqlWithNamedParameters);
     assertEquals(
-        "$1'?it\\'?s'$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'?it\\'?s'?")
+        "$1'?it''?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'?it''?s'?")
             .sqlWithNamedParameters);
     assertEquals(
         "$1'?it\\\"?s'$2",
         parser.convertPositionalParametersToNamedParameters('?', "?'?it\\\"?s'?")
             .sqlWithNamedParameters);
     assertEquals(
-        "$1\"?it\\\"?s\"$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?\"?it\\\"?s\"?")
+        "$1\"?it\"\"?s\"$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?\"?it\"\"?s\"?")
             .sqlWithNamedParameters);
     assertEquals(
-        "$1'''?it\\'?s'''$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s'''?")
+        "$1'''?it''?s'''$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'''?it''?s'''?")
             .sqlWithNamedParameters);
     assertEquals(
-        "$1\"\"\"?it\\\"?s\"\"\"$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?\"\"\"?it\\\"?s\"\"\"?")
+        "$1\"\"\"?it\"\"?s\"\"\"$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?\"\"\"?it\"\"?s\"\"\"?")
             .sqlWithNamedParameters);
 
     // PostgreSQL allows newlines inside string literals.
     assertEquals(
-        "$1'?it\\'?s \n ?it\\'?s'$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'?it\\'?s \n ?it\\'?s'?")
+        "$1'?it''?s \n ?it''?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'?it''?s \n ?it''?s'?")
             .sqlWithNamedParameters);
     assertUnclosedLiteral("?'?it\\'?s \n ?it\\'?s?");
     assertEquals(
-        "$1'''?it\\'?s \n ?it\\'?s'$2",
-        parser.convertPositionalParametersToNamedParameters('?', "?'''?it\\'?s \n ?it\\'?s'?")
+        "$1'''?it''?s \n ?it''?s'$2",
+        parser.convertPositionalParametersToNamedParameters('?', "?'''?it''?s \n ?it''?s'?")
             .sqlWithNamedParameters);
 
     assertEquals(


### PR DESCRIPTION
Some tests used invalid escaping of quotes in PostgreSQL queries. They
assumed that a quote in a quoted string could be escaped by prefixing
it with a backslash. This is however not allowed in PostgreSQL, and
instead the quote must be escaped by including the same quote twice in
the string.
The Spanner Java client library contained a bug that allowed the
backslash-escaped quotes to be accepted. This bug has been fixed in
6.25.7 and these tests therefore need to be modified to be able to
update to that version.

Fixes the build error in #898
