### PR TITLE
ci: temporarily using native-maven-plugin 0.9.11 for testing

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -71,12 +71,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Ptest-native -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Ptest-native -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -71,12 +71,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Ptest-native -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Ptest-native -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -70,12 +70,12 @@ integration)
     RETURN_CODE=$?
     ;;
 graalvm)
-    # Run Unit and Integration Tests with Native Image
+    # Run Unit and Integration Tests with Native Image. Use native-maven-plugin until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 graalvm17)
-    # Run Unit and Integration Tests with Native Image
+    # Run Unit and Integration Tests with Native Image. Use native-maven-plugin 0.9.11 until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
         <artifactId>perfmark-api</artifactId>
         <version>0.25.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <version>0.9.13</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,70 @@
 
   <profiles>
     <profile>
+      <!-- This profile is used to enable GraalVM native image testing -->
+      <id>test-native</id>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>5.8.2</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>junit-platform-native</artifactId>
+          <version>0.9.13</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <!-- Must use older version of surefire plugin for native-image testing. -->
+            <version>2.22.2</version>
+            <configuration>
+              <!-- Include all tests during native image testing. -->
+              <excludes combine.self="override" />
+              <includes>
+                <include>**/IT*.java</include>
+                <!-- Enable unit tests in generated libraries for native image testing. -->
+                <include>**/*ClientTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.13</version>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>test-native</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>--no-server</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>shade</id>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,6 @@
         <artifactId>perfmark-api</artifactId>
         <version>0.25.0</version>
       </dependency>
-      <dependency>
-        <groupId>org.graalvm.buildtools</groupId>
-        <artifactId>native-maven-plugin</artifactId>
-        <version>0.9.13</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -355,8 +350,7 @@
 
   <profiles>
     <profile>
-      <!-- This profile is used to enable GraalVM native image testing -->
-      <id>test-native</id>
+      <id>native-0.9.11</id>
 
       <dependencies>
 
@@ -370,7 +364,7 @@
         <dependency>
           <groupId>org.graalvm.buildtools</groupId>
           <artifactId>junit-platform-native</artifactId>
-          <version>0.9.13</version>
+          <version>0.9.11</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -396,7 +390,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.13</version>
+            <version>0.9.11</version>
             <extensions>true</extensions>
             <executions>
               <execution>
@@ -410,7 +404,6 @@
             <configuration>
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
-                <buildArg>--no-server</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
This PR temporarily introduces a native image compilation profile which fixes the version of the native-maven-plugin to 0.9.11. This is to unblock the shared-config dependency from being upgraded. 
