### PR TITLE
fix: Types.BOOLEAN and Types.BIT should have identical behaviour for nullability

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcParameterStore.java
@@ -858,6 +858,7 @@ class JdbcParameterStore {
         return binder.to((ByteArray) null);
       case Types.BLOB:
         return binder.to((ByteArray) null);
+      case Types.BIT:
       case Types.BOOLEAN:
         return binder.to((Boolean) null);
       case Types.CHAR:

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcParameterStoreTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spanner.jdbc;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -379,6 +380,9 @@ public class JdbcParameterStoreTest {
       params.setParameter(1, BigDecimal.ZERO, type);
       assertEquals(BigDecimal.ZERO, params.getParameter(1));
       verifyParameter(params, Value.bool(false));
+      params.setParameter(1, null, type);
+      assertNull(params.getParameter(1));
+      verifyParameter(params, Value.bool(null));
     }
 
     // types that should lead to numeric


### PR DESCRIPTION
Types.BOOLEAN and Types.BIT should have identical behaviour for nullability. In master, BOOLEAN is nullable but BIT will throw IllegalArgumentException if an attempt is made to set a null value.

Fixes https://github.com/googleapis/java-spanner-jdbc/issues/919