### PR TITLE
fix(java): use custom classpath in native image command

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -71,12 +71,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image. Use native-maven-plugin until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.13 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image. Use native-maven-plugin 0.9.11 until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.13 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 samples)

--- a/pom.xml
+++ b/pom.xml
@@ -351,10 +351,8 @@
 
   <profiles>
     <profile>
-      <id>native-0.9.11</id>
-
+      <id>native-0.9.13</id>
       <dependencies>
-
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
@@ -374,6 +372,25 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <id>build-classpath</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>build-classpath</goal>
+                </goals>
+                <configuration>
+                  <outputProperty>
+                    projectClasspath
+                  </outputProperty>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <!-- Must use older version of surefire plugin for native-image testing. -->
             <version>2.22.2</version>
@@ -391,7 +408,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.11</version>
+            <version>0.9.13</version>
             <extensions>true</extensions>
             <executions>
               <execution>
@@ -406,6 +423,9 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
               </buildArgs>
+              <classpath>
+                projectClasspath
+              </classpath>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -353,11 +353,13 @@
     <profile>
       <id>native-0.9.13</id>
       <dependencies>
+        <!--  Adding dependency in order for it to be included it in the custom native-image classpath   -->
           <dependency>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <version>0.9.13</version> <!-- or newer version -->
           </dependency>
+
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,11 @@
     <profile>
       <id>native-0.9.13</id>
       <dependencies>
+          <dependency>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.13</version> <!-- or newer version -->
+          </dependency>
         <dependency>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
@@ -424,7 +429,7 @@
                 <buildArg>--no-fallback</buildArg>
               </buildArgs>
               <classpath>
-                projectClasspath
+                ${projectClasspath}:/${project.build.directory}/test-classes
               </classpath>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
                 <buildArg>--no-fallback</buildArg>
               </buildArgs>
               <classpath>
-                ${projectClasspath}:/${project.build.directory}/test-classes
+                ${projectClasspath}:/${project.build.directory}/test-classes:${project.build.directory}/classes:/${project.basedir}/src/main/resources:/${project.basedir}/src/test/resources
               </classpath>
             </configuration>
           </plugin>


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-spanner-jdbc/pull/923. This workaround unblocks native-maven-plugin's upgrade to 0.9.13. Once `0.9.14` is released, we can remove this change. 
