### PR TITLE
fix: upgrade native image plugin to 0.9.14 to unblock graalvm 22.2 update

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -70,13 +70,13 @@ integration)
     RETURN_CODE=$?
     ;;
 graalvm)
-    # Run Unit and Integration Tests with Native Image. Use native-maven-plugin until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    # Run Unit and Integration Tests with Native Image.
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.14 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 graalvm17)
-    # Run Unit and Integration Tests with Native Image. Use native-maven-plugin 0.9.11 until https://github.com/graalvm/native-build-tools/issues/279 is fixed.
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.11 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
+    # Run Unit and Integration Tests with Native Image.
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-0.9.14 -Penable-integration-tests test "-Dtest=com.google.cloud.spanner.jdbc.it.**"
     RETURN_CODE=$?
     ;;
 samples)

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
 
   <profiles>
     <profile>
-      <id>native-0.9.11</id>
+      <id>native-0.9.14</id>
 
       <dependencies>
 
@@ -391,7 +391,7 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.11</version>
+            <version>0.9.14</version>
             <extensions>true</extensions>
             <executions>
               <execution>


### PR DESCRIPTION
Upgrading to GraalVM 22.2 requires a minimum of 0.9.13 of the native-maven-plugin. However, 0.9.13 contains an issue that breaks java-spanner-jdbc's build. TODO: Remove this upgrade once java-shared-config 1.5.4 (with the [native-maven-plugin upgrade to 0.9.14](https://github.com/googleapis/java-shared-config/pull/515)) is released. 