### PR TITLE
fix(java): initialize classes at build-time to address native image 22.2.0 issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-spanner-jdbc/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-spanner-jdbc/native-image.properties
@@ -1,3 +1,5 @@
 Args = --initialize-at-build-time==com.google.cloud.spanner.IntegrationTestEnv,\
   com.google.cloud.spanner.jdbc.it.JdbcIntegrationTestEnv,\
-  com.google.common.collect.RegularImmutableMap
+  com.google.common.collect.RegularImmutableMap,\
+  com.google.cloud.spanner.Dialect,\
+  com.google.spanner.admin.database.v1.DatabaseDialect

--- a/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-spanner-jdbc/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-spanner-jdbc/native-image.properties
@@ -2,4 +2,5 @@ Args = --initialize-at-build-time==com.google.cloud.spanner.IntegrationTestEnv,\
   com.google.cloud.spanner.jdbc.it.JdbcIntegrationTestEnv,\
   com.google.common.collect.RegularImmutableMap,\
   com.google.cloud.spanner.Dialect,\
-  com.google.spanner.admin.database.v1.DatabaseDialect
+  com.google.spanner.admin.database.v1.DatabaseDialect,\
+  org.junit.runners.MethodSorters


### PR DESCRIPTION
```
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: No instances of com.google.cloud.spanner.Dialect$1 are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=com.google.cloud.spanner.Dialect$1.
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.checkImageHeapInstance(ClassInitializationFeature.java:140)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.meta.AnalysisUniverse.replaceObject(AnalysisUniverse.java:583)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider.replaceObject(AnalysisConstantReflectionProvider.java:257)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider.interceptValue(AnalysisConstantReflectionProvider.java:228)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.heap.SVMImageHeapScanner.transformFieldValue(SVMImageHeapScanner.java:126)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onFieldValueReachable(ImageHeapScanner.java:331)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.lambda$createImageHeapObject$3(ImageHeapScanner.java:272)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        ... 10 more
Fatal error: org.graalvm.compiler.debug.GraalError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: No instances of com.google.cloud.spanner.Dialect$2 are allowed in the image heap as this class should be initialized at image runtime. To see how this object got instantiated use --trace-object-instantiation=com.google.cloud.spanner.Dialect$2.
```

In GraalVM 22.2.0, `com.google.cloud.spanner.Dialect` gets initialized at build-time, causing `com.google.spanner.admin.database.v1.DatabaseDialect` to also be initialized at build time.