### PR TITLE
chore: correct spanner project reference for ITs

### DIFF
--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -13,12 +13,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "java-docs-samples-testing"
+  value: "gcloud-devel"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "java-docs-samples-testing"
+  value: "gcloud-devel"
 }
 
 env_vars: {


### PR DESCRIPTION
The pom.xml file has reference to `gcloud-devel` project, but the nightly integration kokoro configuration has reference to `java-docs-samples`. This PR sets the project to `gcloud-devel` at both places.

Fixes #820 