### PR TITLE
chore: edit scope of gax dep from test to runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
     </dependency>
@@ -171,11 +176,6 @@
             <artifactId>checker-qual</artifactId>
           </exclusion>
         </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
This PR reverts scope change of `gax` dependency in https://github.com/googleapis/java-spanner-jdbc/pull/918/files.

We now set the scope to `runtime`.

Fixes #1034