### PR TITLE
feat: ignore commit() and rollback() when there is no transaction

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -194,7 +194,9 @@ class JdbcConnection extends AbstractJdbcConnection {
   public void commit() throws SQLException {
     checkClosed();
     try {
-      getSpannerConnection().commit();
+      if (getSpannerConnection().isInTransaction()) {
+        getSpannerConnection().commit();
+      }
     } catch (SpannerException e) {
       throw JdbcSqlExceptionFactory.of(e);
     }
@@ -204,7 +206,9 @@ class JdbcConnection extends AbstractJdbcConnection {
   public void rollback() throws SQLException {
     checkClosed();
     try {
-      getSpannerConnection().rollback();
+      if (getSpannerConnection().isInTransaction()) {
+        getSpannerConnection().rollback();
+      }
     } catch (SpannerException e) {
       throw JdbcSqlExceptionFactory.of(e);
     }


### PR DESCRIPTION
DO NOT MERGE: This is currently a Proof of Concept.

Sometimes it can be beneficial to allow the JDBC connection to accept a commit() or rollback() call even when there is no transaction active. Instead of throwing an error, this option will just ignore the commit() or rollback().
