### PR TITLE
deps: use perfmark-api version via shared dependencies BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,6 @@
         <artifactId>opencensus-contrib-grpc-util</artifactId>
         <version>${opencensus.version}</version>
       </dependency>
-      <dependency>
-        <groupId>io.perfmark</groupId>
-        <artifactId>perfmark-api</artifactId>
-        <version>0.26.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
The shared dependencies BOM declares perfmark-api version already. No need to declare it in this repository. https://github.com/googleapis/java-shared-dependencies/blob/main/third-party-dependencies/pom.xml#LL72C27-L72C33

CC: @burkedavison 