### PR TITLE
fix: support DDL/ClientSideStatement through (Statement/PreparedStatement).executeUpdate API

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
@@ -60,9 +60,11 @@ class JdbcStatement extends AbstractJdbcStatement {
 
   /**
    * @see java.sql.Statement#executeUpdate(String)
-   *     <p>This method allows both DML and DDL statements to be executed. It assumes that the user
-   *     knows what kind of statement is being executed, and the method will therefore return 0 for
-   *     both DML statements that changed 0 rows as well as for all DDL statements.
+   *     <p>This method allows non-returning DML, ClientSideStatement with no result and DDL
+   *     statements to be executed. It assumes that the user knows what kind of statement is being
+   *     executed, and the method will therefore return 0 for both non-returning DML statements that
+   *     changed 0 rows and for all statements that return no result. The method throws a
+   *     SQLException for Returning DML statements.
    */
   @Override
   public int executeUpdate(String sql) throws SQLException {
@@ -75,27 +77,16 @@ class JdbcStatement extends AbstractJdbcStatement {
 
   /**
    * @see java.sql.Statement#executeLargeUpdate(String)
-   *     <p>This method allows both DML and DDL statements to be executed. It assumes that the user
-   *     knows what kind of statement is being executed, and the method will therefore return 0 for
-   *     both DML statements that changed 0 rows as well as for all DDL statements.
+   *     <p>This method allows non-returning DML, ClientSideStatement with no result and DDL
+   *     statements to be executed. It assumes that the user knows what kind of statement is being
+   *     executed, and the method will therefore return 0 for both non-returning DML statements that
+   *     changed 0 rows and for all statements that return no result. The method throws a
+   *     SQLException for Returning DML statements.
    */
   @Override
   public long executeLargeUpdate(String sql) throws SQLException {
     checkClosed();
-    Statement statement = Statement.of(sql);
-    StatementResult result = execute(statement);
-    switch (result.getResultType()) {
-      case RESULT_SET:
-        throw JdbcSqlExceptionFactory.of(
-            "The statement is not a non-returning DML or DDL statement", Code.INVALID_ARGUMENT);
-      case UPDATE_COUNT:
-        return result.getUpdateCount();
-      case NO_RESULT:
-        return 0L;
-      default:
-        throw JdbcSqlExceptionFactory.of(
-            "unknown result: " + result.getResultType(), Code.FAILED_PRECONDITION);
-    }
+    return executeLargeUpdate(Statement.of(sql));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
@@ -62,7 +62,7 @@ class JdbcStatement extends AbstractJdbcStatement {
    * @see java.sql.Statement#executeUpdate(String)
    *     <p>This method allows non-returning DML, ClientSideStatement with no result and DDL
    *     statements to be executed. It assumes that the user knows what kind of statement is being
-   *     executed, and the method will therefore return 0 for both non-returning DML statements that
+   *     executed, and the method will therefore return 0 for non-returning DML statements that
    *     changed 0 rows and for all statements that return no result. The method throws a
    *     SQLException for Returning DML statements.
    */
@@ -79,7 +79,7 @@ class JdbcStatement extends AbstractJdbcStatement {
    * @see java.sql.Statement#executeLargeUpdate(String)
    *     <p>This method allows non-returning DML, ClientSideStatement with no result and DDL
    *     statements to be executed. It assumes that the user knows what kind of statement is being
-   *     executed, and the method will therefore return 0 for both non-returning DML statements that
+   *     executed, and the method will therefore return 0 for non-returning DML statements that
    *     changed 0 rows and for all statements that return no result. The method throws a
    *     SQLException for Returning DML statements.
    */


### PR DESCRIPTION
DDL statements and ClientSideStatements which return no result are now supported through PreparedStatement.executeUpdate and Statement.executeUpdate APIs in ConnectionImpl and should return 0L in that case. 

Exceptions are thrown for cases where the statement is expected to return a ResultSet (for example, DML Returning statements, ClientSideStatements which return ResultSet).

These changes are made on top of changes in https://github.com/googleapis/java-spanner/pull/2324. So, integration tests may not pass until those changes are merged and released.