### PR TITLE
feat: support untyped NULL value parameters

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -83,15 +83,16 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
   @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
-    if (sqlType == Types.OTHER) {
+    if (sqlType == Types.OTHER || sqlType == Types.NULL) {
       parameters.setParameter(
           parameterIndex,
           Value.untyped(
               com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()),
           sqlType,
-          null);
+          /* scaleOrLength = */ null);
     } else {
-      parameters.setParameter(parameterIndex, null, sqlType, null);
+      parameters.setParameter(
+          parameterIndex, /* value = */ null, sqlType, /* scaleOrLength = */ null);
     }
   }
 

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner.jdbc;
 
+import com.google.cloud.spanner.Value;
+import com.google.protobuf.NullValue;
 import com.google.rpc.Code;
 import java.io.InputStream;
 import java.io.Reader;
@@ -81,7 +83,16 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
   @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
-    parameters.setParameter(parameterIndex, null, sqlType, null);
+    if (sqlType == Types.OTHER) {
+      parameters.setParameter(
+          parameterIndex,
+          Value.untyped(
+              com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()),
+          sqlType,
+          null);
+    } else {
+      parameters.setParameter(parameterIndex, null, sqlType, null);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcPreparedStatement.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.spanner.jdbc;
 
-import com.google.cloud.spanner.Value;
-import com.google.protobuf.NullValue;
 import com.google.rpc.Code;
 import java.io.InputStream;
 import java.io.Reader;
@@ -83,17 +81,8 @@ abstract class AbstractJdbcPreparedStatement extends JdbcStatement implements Pr
   @Override
   public void setNull(int parameterIndex, int sqlType) throws SQLException {
     checkClosed();
-    if (sqlType == Types.OTHER || sqlType == Types.NULL) {
-      parameters.setParameter(
-          parameterIndex,
-          Value.untyped(
-              com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()),
-          sqlType,
-          /* scaleOrLength = */ null);
-    } else {
-      parameters.setParameter(
-          parameterIndex, /* value = */ null, sqlType, /* scaleOrLength = */ null);
-    }
+    parameters.setParameter(
+        parameterIndex, /* value = */ null, sqlType, /* scaleOrLength = */ null);
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcPreparedStatementTest.java
@@ -300,7 +300,7 @@ public class JdbcPreparedStatementTest {
 
   @Test
   public void testSetNullValues() throws SQLException {
-    final int numberOfParameters = 27;
+    final int numberOfParameters = 29;
     String sql = generateSqlWithParameters(numberOfParameters);
     try (JdbcPreparedStatement ps = new JdbcPreparedStatement(createMockConnection(), sql)) {
       int index = 0;
@@ -331,6 +331,8 @@ public class JdbcPreparedStatementTest {
       ps.setNull(++index, Types.BIT);
       ps.setNull(++index, Types.VARBINARY);
       ps.setNull(++index, Types.VARCHAR);
+      ps.setNull(++index, Types.OTHER);
+      ps.setNull(++index, Types.NULL);
       assertEquals(numberOfParameters, index);
 
       JdbcParameterMetaData pmd = ps.getParameterMetaData();

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcDatabaseMetaDataTest.java
@@ -512,7 +512,8 @@ public class ITJdbcDatabaseMetaDataTest extends ITAbstractJdbcTest {
           new IndexInfo("TableWithRef", false, "PRIMARY_KEY", 1, "Id", "A"),
           new IndexInfo("TableWithRef", true, "FOREIGN_KEY", 1, "RefFloat", "A"),
           new IndexInfo("TableWithRef", true, "FOREIGN_KEY", 2, "RefString", "A"),
-          new IndexInfo("TableWithRef", true, "FOREIGN_KEY", 3, "RefDate", "A"));
+          new IndexInfo("TableWithRef", true, "FOREIGN_KEY", 3, "RefDate", "A"),
+          new IndexInfo("all_nullable_types", false, "PRIMARY_KEY", 1, "ColInt64", "A"));
 
   @Test
   public void testGetIndexInfo() throws SQLException {
@@ -860,7 +861,8 @@ public class ITJdbcDatabaseMetaDataTest extends ITAbstractJdbcTest {
           new Table("SingersView", "VIEW"),
           new Table("Songs"),
           new Table("TableWithAllColumnTypes"),
-          new Table("TableWithRef"));
+          new Table("TableWithRef"),
+          new Table("all_nullable_types"));
 
   @Test
   public void testGetTables() throws SQLException {

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPgDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPgDatabaseMetaDataTest.java
@@ -420,6 +420,7 @@ public class ITJdbcPgDatabaseMetaDataTest extends ITAbstractJdbcTest {
           new IndexInfo("albums", false, "PRIMARY_KEY", 1, "singerid", "A"),
           new IndexInfo("albums", false, "PRIMARY_KEY", 2, "albumid", "A"),
           new IndexInfo("albums", true, "albumsbyalbumtitle", 1, "albumtitle", "A"),
+          new IndexInfo("all_nullable_types", false, "PRIMARY_KEY", 1, "colint64", "A"),
           new IndexInfo("concerts", false, "PRIMARY_KEY", 1, "venueid", "A"),
           new IndexInfo("concerts", false, "PRIMARY_KEY", 2, "singerid", "A"),
           new IndexInfo("concerts", false, "PRIMARY_KEY", 3, "concertdate", "A"),
@@ -790,6 +791,7 @@ public class ITJdbcPgDatabaseMetaDataTest extends ITAbstractJdbcTest {
   private static final List<Table> EXPECTED_TABLES =
       Arrays.asList(
           new Table("albums"),
+          new Table("all_nullable_types"),
           new Table("concerts"),
           new Table("singers"),
           // TODO: Enable when views are supported for PostgreSQL dialect databases.

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
@@ -1294,6 +1294,29 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
     }
   }
 
+  @Test
+  public void test13_InsertUntypedNullValues() throws SQLException {
+    try (Connection connection = createConnection(env, database)) {
+      try (PreparedStatement preparedStatement =
+          connection.prepareStatement(
+              "insert into all_nullable_types ("
+                  + "ColInt64, ColFloat64, ColBool, ColString, ColBytes, ColDate, ColTimestamp, ColNumeric, ColJson, "
+                  + "ColInt64Array, ColFloat64Array, ColBoolArray, ColStringArray, ColBytesArray, ColDateArray, ColTimestampArray, ColNumericArray, ColJsonArray) "
+                  + "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+        for (int param = 1;
+            param <= preparedStatement.getParameterMetaData().getParameterCount();
+            param++) {
+          preparedStatement.setNull(param, Types.OTHER);
+        }
+        if (getDialect() == Dialect.POSTGRESQL) {
+          // PostgreSQL-dialect databases do not allow NULLs in primary keys.
+          preparedStatement.setLong(1, 1L);
+        }
+        assertEquals(1, preparedStatement.executeUpdate());
+      }
+    }
+  }
+
   private List<String> readValuesFromFile(String filename) {
     StringBuilder builder = new StringBuilder();
     try (InputStream stream = ITJdbcPreparedStatementTest.class.getResourceAsStream(filename)) {

--- a/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/it/ITJdbcPreparedStatementTest.java
@@ -1313,6 +1313,16 @@ public class ITJdbcPreparedStatementTest extends ITAbstractJdbcTest {
           preparedStatement.setLong(1, 1L);
         }
         assertEquals(1, preparedStatement.executeUpdate());
+
+        // Verify that calling preparedStatement.setObject(index, null) works.
+        for (int param = 1;
+            param <= preparedStatement.getParameterMetaData().getParameterCount();
+            param++) {
+          preparedStatement.setObject(param, null);
+        }
+        // We need a different primary key value to insert another row.
+        preparedStatement.setLong(1, 2L);
+        assertEquals(1, preparedStatement.executeUpdate());
       }
     }
   }

--- a/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables.sql
+++ b/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables.sql
@@ -97,6 +97,29 @@ CREATE TABLE TableWithAllColumnTypes (
 ) PRIMARY KEY (ColInt64)
 ;
 
+CREATE TABLE all_nullable_types (
+    ColInt64	    INT64,
+    ColFloat64	    FLOAT64,
+    ColBool		    BOOL,
+    ColString		STRING(100),
+    ColBytes		BYTES(100),
+    ColDate		    DATE,
+    ColTimestamp	TIMESTAMP,
+    ColNumeric	    NUMERIC,
+    ColJson		    JSON,
+    
+    ColInt64Array		ARRAY<INT64>,
+    ColFloat64Array     ARRAY<FLOAT64>,
+    ColBoolArray		ARRAY<BOOL>,
+    ColStringArray	    ARRAY<STRING(100)>,
+    ColBytesArray		ARRAY<BYTES(100)>,
+    ColDateArray		ARRAY<DATE>,
+    ColTimestampArray	ARRAY<TIMESTAMP>,
+    ColNumericArray	    ARRAY<NUMERIC>,
+    ColJsonArray		ARRAY<JSON>,
+) PRIMARY KEY (ColInt64)
+;
+
 CREATE TABLE TableWithRef (
   Id          INT64       NOT NULL,
   RefFloat    FLOAT64     NOT NULL,

--- a/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables_Emulator.sql
+++ b/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables_Emulator.sql
@@ -92,6 +92,29 @@ CREATE TABLE TableWithAllColumnTypes (
 ) PRIMARY KEY (ColInt64)
 ;
 
+CREATE TABLE all_nullable_types (
+    ColInt64	    INT64,
+    ColFloat64	    FLOAT64,
+    ColBool		    BOOL,
+    ColString		STRING(100),
+    ColBytes		BYTES(100),
+    ColDate		    DATE,
+    ColTimestamp	TIMESTAMP,
+    ColNumeric	    NUMERIC,
+    ColJson		    JSON,
+
+    ColInt64Array		ARRAY<INT64>,
+    ColFloat64Array     ARRAY<FLOAT64>,
+    ColBoolArray		ARRAY<BOOL>,
+    ColStringArray	    ARRAY<STRING(100)>,
+    ColBytesArray		ARRAY<BYTES(100)>,
+    ColDateArray		ARRAY<DATE>,
+    ColTimestampArray	ARRAY<TIMESTAMP>,
+    ColNumericArray	    ARRAY<NUMERIC>,
+    ColJsonArray		ARRAY<JSON>,
+) PRIMARY KEY (ColInt64)
+;
+
 CREATE TABLE TableWithRef (
   Id          INT64       NOT NULL,
   RefFloat    FLOAT64     NOT NULL,

--- a/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables_PG.sql
+++ b/src/test/resources/com/google/cloud/spanner/jdbc/it/CreateMusicTables_PG.sql
@@ -74,6 +74,27 @@ CREATE TABLE TableWithAllColumnTypes (
     ColNumeric   NUMERIC NOT NULL,
     ColJson      VARCHAR NOT NULL
 );
+CREATE TABLE all_nullable_types (
+    ColInt64	    bigint primary key,
+    ColFloat64	    float8,
+    ColBool		    boolean,
+    ColString		varchar(100),
+    ColBytes		bytea,
+    ColDate		    date,
+    ColTimestamp	timestamptz,
+    ColNumeric	    numeric,
+    ColJson		    jsonb,
+
+    ColInt64Array		bigint[],
+    ColFloat64Array     float8[],
+    ColBoolArray		boolean[],
+    ColStringArray	    varchar(100)[],
+    ColBytesArray		bytea[],
+    ColDateArray		date[],
+    ColTimestampArray	timestamptz[],
+    ColNumericArray	    numeric[],
+    ColJsonArray		jsonb[]
+);
 
 CREATE TABLE TableWithRef (
     Id          BIGINT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Support untyped null parameter values for `PreparedStatement`. This will allow users to add null values as a statement parameter value without having to know what type the column that the parameter is bound to uses.