### PR TITLE
ci: javadoc as a required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -39,6 +39,7 @@ branchProtectionRules:
     - OwlBot Post Processor
     - 'Kokoro - Test: Java GraalVM Native Image'
     - 'Kokoro - Test: Java 17 GraalVM Native Image'
+    - javadoc
 
 # Identifies the protection rule pattern. Name of the branch to be protected.
 # Defaults to `main`


### PR DESCRIPTION
Manual configuration of the required check at Settings tab has been reverted. Adding that back via sync-repo-settings.yaml.
