### PR TITLE
build: stop auto merging releases

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -99,5 +99,5 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.payload.pull_request.number,
-            labels: ['kokoro:force-run', 'automerge']
+            labels: ['kokoro:force-run']
           });


### PR DESCRIPTION
Stop auto-merging releases, even if they only contain dependency updates, as it causes a too large number of releases to go out.
