### PR TITLE
deps: remove specific JDBC version from samples

### DIFF
--- a/.github/workflows/spring-data-mybatis-sample.yaml
+++ b/.github/workflows/spring-data-mybatis-sample.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Github action job to test core java library features on
+# downstream client libraries before they are released.
+on:
+  pull_request:
+name: spring-data-mybatis-sample
+jobs:
+  spring-data-jdbc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Run tests
+        run: mvn test
+        working-directory: samples/spring-data-mybatis

--- a/samples/spring-data-jdbc/pom.xml
+++ b/samples/spring-data-jdbc/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/samples/spring-data-mybatis/pom.xml
+++ b/samples/spring-data-mybatis/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.22.0</version>
+        <version>26.23.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner-jdbc</artifactId>
-      <version>2.12.1</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Removes the specific JDBC version from the samples. This is no longer needed, as the BOM now contains a JDBC driver version that is up-to-date enough to work with these samples (they require RETURN_GENERATED_KEYS).
- Adds a GitHub Actions workflow for testing the MyBatis sample.