### PR TITLE
test: verify execution of client side statements

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
@@ -153,6 +153,11 @@ class JdbcStatement extends AbstractJdbcStatement implements CloudSpannerJdbcSta
             "Result does not contain an update count", Code.FAILED_PRECONDITION);
       }
       return updateCount;
+    } catch (UnsupportedOperationException unsupportedOperationException) {
+      throw JdbcSqlExceptionFactory.of(
+          unsupportedOperationException.getMessage(),
+          Code.FAILED_PRECONDITION,
+          unsupportedOperationException);
     } finally {
       resultSet.close();
     }


### PR DESCRIPTION
Verifies that client-side statements can now also be executed using the executeQuery and executeUpdate methods.

Replaces #1152
