### PR TITLE
deps: update dependency com.google.cloud:google-cloud-spanner-bom to v6.57.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.56.0</version>
+        <version>6.57.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -191,6 +191,8 @@ public class JdbcDriver implements Driver {
         if (matcher.matches()) {
           // strip 'jdbc:' from the URL, add any extra properties and pass on to the generic
           // Connection API
+          // TODO: Remove when statement cache should be enabled by default.
+          System.setProperty("spanner.statement_cache_size_mb", "0");
           String connectionUri = appendPropertiesToUrl(url.substring(5), info);
           ConnectionOptions options = ConnectionOptions.newBuilder().setUri(connectionUri).build();
           JdbcConnection connection = new JdbcConnection(url, options);

--- a/src/test/java/com/google/cloud/spanner/jdbc/PartitionedQueryMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/PartitionedQueryMockServerTest.java
@@ -158,7 +158,7 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
         partitionStatement.setBoolean(1, true);
         try (ResultSet results = partitionStatement.executeQuery()) {
           assertNotNull(results.getMetaData());
-          assertEquals(18, results.getMetaData().getColumnCount());
+          assertEquals(22, results.getMetaData().getColumnCount());
           int rowCount = 0;
           while (results.next()) {
             rowCount++;
@@ -376,7 +376,7 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
       try (ResultSet results =
           connection.createStatement().executeQuery("select * from my_table where active=true")) {
         assertNotNull(results.getMetaData());
-        assertEquals(18, results.getMetaData().getColumnCount());
+        assertEquals(22, results.getMetaData().getColumnCount());
         int rowCount = 0;
         while (results.next()) {
           rowCount++;
@@ -482,7 +482,7 @@ public class PartitionedQueryMockServerTest extends AbstractMockServerTest {
       try (ResultSet results =
           connection.createStatement().executeQuery("select * from my_table where active=true")) {
         assertNotNull(results.getMetaData());
-        assertEquals(18, results.getMetaData().getColumnCount());
+        assertEquals(22, results.getMetaData().getColumnCount());
         int rowCount = 0;
         while (results.next()) {
           rowCount++;

--- a/src/test/java/com/google/cloud/spanner/jdbc/PgNumericResultSetTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/PgNumericResultSetTest.java
@@ -491,7 +491,8 @@ public class PgNumericResultSetTest {
           resultSetMatcherFrom(resultSet, ResultSet::getBytes, ResultSet::getBytes);
 
       matcher.nextAndAssertError(
-          IllegalStateException.class, "expected BYTES but was NUMERIC<PG_NUMERIC>");
+          IllegalStateException.class,
+          "expected one of [[PROTO, BYTES]] but was NUMERIC<PG_NUMERIC>");
       matcher.nextAndAssertEquals(null);
     }
   }
@@ -600,7 +601,8 @@ public class PgNumericResultSetTest {
           resultSetMatcherFrom(resultSet, ResultSet::getBlob, ResultSet::getBlob);
 
       matcher.nextAndAssertError(
-          IllegalStateException.class, "expected BYTES but was NUMERIC<PG_NUMERIC>");
+          IllegalStateException.class,
+          "expected one of [[PROTO, BYTES]] but was NUMERIC<PG_NUMERIC>");
       matcher.nextAndAssertEquals(null);
     }
   }


### PR DESCRIPTION
Updates the Spanner client to 6.57.0 and modifies some test cases to work with the newest version of the Spanner client. The manual changes other than the dependency update are:
1. The Spanner client now supports PROTO and PROTO ENUM columns. This is also reflected in the RandomResultSetGenerator, which means that the number of columns is increased from 18 to 22.
2. The above addition of PROTO and PROTO ENUM means that the error message changes when you try to get a blob with a wrong column.
3. The newly introduced statement cache must be disabled, as there is a small bug that prevents the first query to include any default query options (e.g. optimizer version).
