### PR TITLE
chore: remove custom type name implementation

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
@@ -71,65 +71,7 @@ abstract class AbstractJdbcWrapper implements Wrapper {
   }
 
   static String getSpannerTypeName(Type type, Dialect dialect) {
-    // TODO: Use com.google.cloud.spanner.Type#getSpannerTypeName() when available.
-    Preconditions.checkNotNull(type);
-    switch (type.getCode()) {
-      case BOOL:
-        return dialect == Dialect.POSTGRESQL ? "boolean" : "BOOL";
-      case BYTES:
-        return dialect == Dialect.POSTGRESQL ? "bytea" : "BYTES";
-      case DATE:
-        return dialect == Dialect.POSTGRESQL ? "date" : "DATE";
-      case FLOAT64:
-        return dialect == Dialect.POSTGRESQL ? "double precision" : "FLOAT64";
-      case INT64:
-        return dialect == Dialect.POSTGRESQL ? "bigint" : "INT64";
-      case NUMERIC:
-        return "NUMERIC";
-      case PG_NUMERIC:
-        return "numeric";
-      case STRING:
-        return dialect == Dialect.POSTGRESQL ? "character varying" : "STRING";
-      case JSON:
-        return "JSON";
-      case PG_JSONB:
-        return "jsonb";
-      case TIMESTAMP:
-        return dialect == Dialect.POSTGRESQL ? "timestamp with time zone" : "TIMESTAMP";
-      case STRUCT:
-        return "STRUCT";
-      case ARRAY:
-        switch (type.getArrayElementType().getCode()) {
-          case BOOL:
-            return dialect == Dialect.POSTGRESQL ? "boolean[]" : "ARRAY<BOOL>";
-          case BYTES:
-            return dialect == Dialect.POSTGRESQL ? "bytea[]" : "ARRAY<BYTES>";
-          case DATE:
-            return dialect == Dialect.POSTGRESQL ? "date[]" : "ARRAY<DATE>";
-          case FLOAT64:
-            return dialect == Dialect.POSTGRESQL ? "double precision[]" : "ARRAY<FLOAT64>";
-          case INT64:
-            return dialect == Dialect.POSTGRESQL ? "bigint[]" : "ARRAY<INT64>";
-          case NUMERIC:
-            return "ARRAY<NUMERIC>";
-          case PG_NUMERIC:
-            return "numeric[]";
-          case STRING:
-            return dialect == Dialect.POSTGRESQL ? "character varying[]" : "ARRAY<STRING>";
-          case JSON:
-            return "ARRAY<JSON>";
-          case PG_JSONB:
-            return "jsonb[]";
-          case TIMESTAMP:
-            return dialect == Dialect.POSTGRESQL
-                ? "timestamp with time zone[]"
-                : "ARRAY<TIMESTAMP>";
-          case STRUCT:
-            return "ARRAY<STRUCT>";
-        }
-      default:
-        return null;
-    }
+    return Preconditions.checkNotNull(type).getSpannerTypeName(dialect);
   }
 
   /**


### PR DESCRIPTION
Remove the custom type name implementation in the JDBC driver and rely on the implementation in the Java client library.
