### PR TITLE
chore: restore sdk-platform-java-config changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
   </description>
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.4</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.27.0</version>
   </parent>
   <developers>
     <developer>
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.27.0</version>
+        <version>${google-cloud-shared-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/java-spanner-jdbc/pull/1486. These changes were overridden by release-please in https://github.com/googleapis/java-spanner-jdbc/pull/1484 

Thanks for catching this @alicejli!