### PR TITLE
deps: bump Spanner client to 6.62.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.27.0</version>
+    <version>3.28.1</version>
   </parent>
   <developers>
     <developer>
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.61.0</version>
+        <version>6.62.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Bumping both Spanner client to 6.62.0 and cloud-sdk-java-config to 3.28.1 at the same time, as bumping them separately causes dependency issues.