### PR TITLE
chore: add connection helper to get Spanner instance

### DIFF
--- a/src/main/java/com/google/cloud/spanner/connection/ConnectionHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/ConnectionHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import com.google.cloud.spanner.Spanner;
+
+/** Static helper class to get the {@link Spanner} instance from the underlying connection. */
+public class ConnectionHelper {
+
+  /** Private constructor to prevent instantiation. */
+  private ConnectionHelper() {}
+
+  public static Spanner getSpanner(Connection connection) {
+    // TODO: Remove once getSpanner() has been added to the public interface.
+    return ((ConnectionImpl) connection).getSpanner();
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
@@ -17,8 +17,10 @@
 package com.google.cloud.spanner.jdbc;
 
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
+import com.google.cloud.spanner.connection.ConnectionHelper;
 import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.rpc.Code;
@@ -76,6 +78,10 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
 
   ConnectionOptions getConnectionOptions() {
     return options;
+  }
+
+  Spanner getSpanner() {
+    return ConnectionHelper.getSpanner(this.spanner);
   }
 
   @Override


### PR DESCRIPTION
Add a connection helper to get the underlying Spanner instance. This helper will be removed once the getSpanner() method has been made public in the Java client library.
