### PR TITLE
fix: release ResultSet on Statement#close() 

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcStatement.java
@@ -359,7 +359,7 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
   }
 
   @Override
-  public void close() {
+  public void close() throws SQLException {
     this.closed = true;
   }
 

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcStatement.java
@@ -63,6 +63,12 @@ class JdbcStatement extends AbstractJdbcStatement implements CloudSpannerJdbcSta
   }
 
   @Override
+  public void close() throws SQLException {
+    setCurrentResultSet(null);
+    super.close();
+  }
+
+  @Override
   public ResultSet executeQuery(String sql) throws SQLException {
     checkClosed();
     return executeQuery(Statement.of(sql));
@@ -267,7 +273,7 @@ class JdbcStatement extends AbstractJdbcStatement implements CloudSpannerJdbcSta
         // keys. We can safely use '==', as the addReturningToStatement(..) method returns the same
         // instance if no generated keys were requested.
         if (statementWithReturning == statement) {
-          currentResultSet = JdbcResultSet.of(this, result.getResultSet());
+          setCurrentResultSet(JdbcResultSet.of(this, result.getResultSet()));
           currentUpdateCount = JdbcConstants.STATEMENT_RESULT_SET;
           return true;
         }
@@ -275,11 +281,11 @@ class JdbcStatement extends AbstractJdbcStatement implements CloudSpannerJdbcSta
         this.currentUpdateCount = extractUpdateCountAndClose(result.getResultSet());
         return false;
       case UPDATE_COUNT:
-        currentResultSet = null;
+        setCurrentResultSet(null);
         currentUpdateCount = result.getUpdateCount();
         return false;
       case NO_RESULT:
-        currentResultSet = null;
+        setCurrentResultSet(null);
         currentUpdateCount = JdbcConstants.STATEMENT_NO_RESULT;
         return false;
       default:
@@ -292,6 +298,13 @@ class JdbcStatement extends AbstractJdbcStatement implements CloudSpannerJdbcSta
   public ResultSet getResultSet() throws SQLException {
     checkClosed();
     return currentResultSet;
+  }
+
+  void setCurrentResultSet(ResultSet resultSet) throws SQLException {
+    if (this.currentResultSet != null) {
+      this.currentResultSet.close();
+    }
+    this.currentResultSet = resultSet;
   }
 
   /**

--- a/src/test/java/com/google/cloud/spanner/jdbc/StatementResourcesTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/StatementResourcesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.jdbc;
+
+import com.google.cloud.spanner.connection.AbstractMockServerTest;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StatementResourcesTest extends AbstractMockServerTest {
+
+  private String createUrl() {
+    return String.format(
+        "jdbc:cloudspanner://localhost:%d/projects/%s/instances/%s/databases/%s"
+            + "?usePlainText=true;minSessions=2;maxSessions=2",
+        getPort(), "proj", "inst", "db");
+  }
+
+  @Test
+  public void testQueryWithExecuteAndNoRead() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("SELECT 1");
+        statement.execute("SELECT 1");
+        statement.execute("SELECT 1");
+      }
+    }
+  }
+
+}

--- a/src/test/java/com/google/cloud/spanner/jdbc/StatementResourcesTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/StatementResourcesTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.jdbc;
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.junit.Test;
@@ -27,23 +28,61 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class StatementResourcesTest extends AbstractMockServerTest {
+  private static final int MIN_SESSIONS = 1;
+  private static final int MAX_SESSIONS = 2;
 
   private String createUrl() {
     return String.format(
         "jdbc:cloudspanner://localhost:%d/projects/%s/instances/%s/databases/%s"
-            + "?usePlainText=true;minSessions=2;maxSessions=2",
-        getPort(), "proj", "inst", "db");
+            + "?usePlainText=true;minSessions=%d;maxSessions=%d",
+        getPort(), "proj", "inst", "db", MIN_SESSIONS, MAX_SESSIONS);
   }
 
   @Test
-  public void testQueryWithExecuteAndNoRead() throws SQLException {
+  public void testMultipleQueriesOnOneStatement() throws SQLException {
     try (Connection connection = DriverManager.getConnection(createUrl())) {
       try (Statement statement = connection.createStatement()) {
-        statement.execute("SELECT 1");
-        statement.execute("SELECT 1");
-        statement.execute("SELECT 1");
+        for (int i = 0; i < MAX_SESSIONS + 1; i++) {
+          // Execute a query without reading or closing the result.
+          statement.execute("SELECT 1");
+        }
       }
     }
   }
 
+  @Test
+  public void testMultipleStatementsWithOneQuery() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      for (int i = 0; i < MAX_SESSIONS + 1; i++) {
+        try (Statement statement = connection.createStatement()) {
+          // Execute a query without reading or closing the result.
+          statement.execute("SELECT 1");
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testMultipleQueriesOnOnePreparedStatement() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      try (PreparedStatement statement = connection.prepareStatement("SELECT 1")) {
+        for (int i = 0; i < MAX_SESSIONS + 1; i++) {
+          // Execute a query without reading or closing the result.
+          statement.execute();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testMultiplePreparedStatementsWithOneQuery() throws SQLException {
+    try (Connection connection = DriverManager.getConnection(createUrl())) {
+      for (int i = 0; i < MAX_SESSIONS + 1; i++) {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT 1")) {
+          // Execute a query without reading or closing the result.
+          statement.execute();
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Release the underlying resources of any ResultSet when Statement#close()
is called. This is necessary in case someone executes a query in
auto-commit mode using Statement#execute(String), and never reads and/or
closes the result that was returned.