### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,7 @@
   "repo_short": "java-spanner-jdbc",
   "distribution_name": "com.google.cloud:google-cloud-spanner-jdbc",
   "library_type": "OTHER",
-  "codeowner_team": "@googleapis/api-spanner-java"
+  "codeowner_team": "@googleapis/api-spanner-java",
+  "recommended_package": "com.google.cloud.spanner.jdbc"
 }
 


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details