### PR TITLE
feat: support endpoint connection URL property

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -84,6 +84,12 @@ import java.util.regex.Pattern;
  *       instance and database in the connection string will automatically be created if these do
  *       not yet exist on the emulator. This means that you do not need to execute any `gcloud`
  *       commands on the emulator to create the instance and database before you can connect to it.
+ *   <li>endpoint (string): Set this property to specify a custom endpoint that the JDBC driver
+ *       should connect to. You can use this property in combination with the autoConfigEmulator
+ *       property to instruct the JDBC driver to connect to an emulator instance that uses a
+ *       randomly assigned port numer. See <a
+ *       href="https://github.com/googleapis/java-spanner-jdbc/blob/main/src/test/java/com/google/cloud/spanner/jdbc/ConcurrentTransactionOnEmulatorTest.java">ConcurrentTransactionOnEmulatorTest</a>
+ *       for a concrete example of how to use this property.
  *   <li>usePlainText (boolean): Sets whether the JDBC connection should establish an unencrypted
  *       connection to the server. This option can only be used when connecting to a local emulator
  *       that does not require an encrypted connection, and that does not require authentication.
@@ -101,8 +107,7 @@ import java.util.regex.Pattern;
  *       connection.
  *   <li>retryAbortsInternally (boolean): Sets the initial retryAbortsInternally mode for the
  *       connection. Default is true. @see {@link
- *       com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection#setRetryAbortsInternally(boolean)}
- *       for more information.
+ *       CloudSpannerJdbcConnection#setRetryAbortsInternally(boolean)} for more information.
  *   <li>minSessions (int): Sets the minimum number of sessions in the backing session pool.
  *       Defaults to 100.
  *   <li>maxSessions (int): Sets the maximum number of sessions in the backing session pool.


### PR DESCRIPTION
Added support for an 'endpoint' connection URL property. This property can be added to either the Connection URL or the Properties object that is used to create a Connection, and can be used in combination with the autoConfigEmulator connection property to connect to an emulator instance that uses a randomly assigned port number.

See https://github.com/googleapis/java-spanner-jdbc/blob/main/src/test/java/com/google/cloud/spanner/jdbc/ConcurrentTransactionOnEmulatorTest.java for an example on how to use this property.
