### PR TITLE
docs: support concurrent transactions on the emulator

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -84,6 +84,13 @@ import java.util.regex.Pattern;
  *       instance and database in the connection string will automatically be created if these do
  *       not yet exist on the emulator. This means that you do not need to execute any `gcloud`
  *       commands on the emulator to create the instance and database before you can connect to it.
+ *       Setting this property to true also enables running concurrent transactions on the emulator.
+ *       The emulator aborts any concurrent transaction on the emulator, and the JDBC driver works
+ *       around this by automatically setting a savepoint after each statement that is executed.
+ *       When the transaction has been aborted by the emulator and the JDBC connection wants to
+ *       continue with that transaction, the transaction is replayed up until the savepoint that had
+ *       automatically been set after the last statement that was executed before the transaction
+ *       was aborted by the emulator.
  *   <li>endpoint (string): Set this property to specify a custom endpoint that the JDBC driver
  *       should connect to. You can use this property in combination with the autoConfigEmulator
  *       property to instruct the JDBC driver to connect to an emulator instance that uses a


### PR DESCRIPTION
Documents the support for overlapping transactions on the emulator in the Connection API, even when these are executed on one thread. This is normally not supported, as it requires multiple transactions to run concurrently on the emulator.

This change works around that by keeping track of what the active transaction on the emulator is, and then abort that transaction when another transaction needs to make progress. The transaction that was aborted will be retried up to the point where it was when it again wants to make progress.

This step-by-step progress is implemented by automatically setting a savepoint in the transaction after each successful step. The transaction is then rolled back to that savepoint when another transaction needs to make progress.

The feature is only enabled if the `autoConfigEmulator` flag is enabled.
