### PR TITLE
deps: remove open-telemetry dependency import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-bom</artifactId>
-        <version>1.38.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>${google-cloud-shared-dependencies.version}</version>


### PR DESCRIPTION
Remove the open-telemetry dependency import, as it is already defined in the shared dependencies.
