### PR TITLE
feat: update DatabaseMetaData to include named schemas

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
@@ -419,27 +419,27 @@ class JdbcDatabaseMetaData extends AbstractJdbcWrapper implements DatabaseMetaDa
 
   @Override
   public boolean supportsSchemasInDataManipulation() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsSchemasInProcedureCalls() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsSchemasInTableDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsSchemasInIndexDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsSchemasInPrivilegeDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
@@ -602,7 +602,7 @@ class JdbcDatabaseMetaData extends AbstractJdbcWrapper implements DatabaseMetaDa
 
   @Override
   public int getMaxSchemaNameLength() {
-    return 0;
+    return 128;
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
@@ -112,7 +112,7 @@ public class JdbcDatabaseMetaDataTest {
     assertEquals(8000, meta.getMaxIndexLength());
     assertEquals(0, meta.getMaxProcedureNameLength());
     assertEquals(0, meta.getMaxRowSize());
-    assertEquals(0, meta.getMaxSchemaNameLength());
+    assertEquals(128, meta.getMaxSchemaNameLength());
     assertEquals(1000000, meta.getMaxStatementLength());
     assertEquals(0, meta.getMaxStatements());
     assertEquals(128, meta.getMaxTableNameLength());
@@ -245,11 +245,11 @@ public class JdbcDatabaseMetaDataTest {
     assertTrue(meta.supportsResultSetHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT));
     assertFalse(meta.supportsResultSetHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT));
     assertFalse(meta.supportsSavepoints());
-    assertFalse(meta.supportsSchemasInDataManipulation());
-    assertFalse(meta.supportsSchemasInIndexDefinitions());
-    assertFalse(meta.supportsSchemasInPrivilegeDefinitions());
-    assertFalse(meta.supportsSchemasInProcedureCalls());
-    assertFalse(meta.supportsSchemasInTableDefinitions());
+    assertTrue(meta.supportsSchemasInDataManipulation());
+    assertTrue(meta.supportsSchemasInIndexDefinitions());
+    assertTrue(meta.supportsSchemasInPrivilegeDefinitions());
+    assertTrue(meta.supportsSchemasInProcedureCalls());
+    assertTrue(meta.supportsSchemasInTableDefinitions());
     assertFalse(meta.supportsSelectForUpdate());
     assertFalse(meta.supportsStatementPooling());
     assertFalse(meta.supportsStoredFunctionsUsingCallSyntax());


### PR DESCRIPTION
Updates the results that we return for methods that relate to named schemas in `DatabaseMetaData`,  as Spanner now supports named schemas.