### PR TITLE
docs: simplify dialect detection in Spring Data JDBC sample

### DIFF
--- a/samples/spring-data-jdbc/src/main/java/com/google/cloud/spanner/sample/JdbcConfiguration.java
+++ b/samples/spring-data-jdbc/src/main/java/com/google/cloud/spanner/sample/JdbcConfiguration.java
@@ -16,17 +16,14 @@
 
 package com.google.cloud.spanner.sample;
 
-import com.google.cloud.spanner.jdbc.JdbcSqlException;
-import com.google.rpc.Code;
+import com.google.cloud.spanner.jdbc.CloudSpannerJdbcConnection;
 import io.opentelemetry.api.OpenTelemetry;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.PostgresDialect;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
@@ -48,42 +45,12 @@ public class JdbcConfiguration extends AbstractJdbcConfiguration {
 
   /** Returns true if the current database is a Cloud Spanner PostgreSQL database. */
   public static boolean isCloudSpannerPG(JdbcOperations operations) {
-    try {
-      Long value =
-          operations.queryForObject(
-              "select 1 "
-                  + "from information_schema.database_options "
-                  + "where schema_name='public' "
-                  + "and option_name='database_dialect' "
-                  + "and option_value='POSTGRESQL'",
-              Long.class);
-      // Shouldn't really be anything else than 1 if the query succeeded, but this avoids complaints
-      // from the compiler.
-      if (Objects.equals(1L, value)) {
-        return true;
-      }
-    } catch (IncorrectResultSizeDataAccessException exception) {
-      // This indicates that it is a valid Cloud Spanner database, but not one that uses the
-      // PostgreSQL dialect.
-      throw new RuntimeException(
-          "The selected Cloud Spanner database does not use the PostgreSQL dialect");
-    } catch (DataAccessException exception) {
-      if (exception.getCause() instanceof JdbcSqlException) {
-        JdbcSqlException jdbcSqlException = (JdbcSqlException) exception.getCause();
-        if (jdbcSqlException.getCode() == Code.PERMISSION_DENIED
-            || jdbcSqlException.getCode() == Code.NOT_FOUND) {
-          throw new RuntimeException(
-              "Failed to get the dialect of the Cloud Spanner database. "
-                  + "Please check that the selected database exists and that you have permission to access it. "
-                  + "Cause: "
-                  + exception.getCause().getMessage(),
-              exception.getCause());
-        }
-      }
-      // ignore and fall through
-    } catch (Throwable exception) {
-      // ignore and fall through
-    }
-    return false;
+    return Boolean.TRUE.equals(
+        operations.execute(
+            (ConnectionCallback<Boolean>)
+                connection ->
+                    connection.isWrapperFor(CloudSpannerJdbcConnection.class)
+                        && com.google.cloud.spanner.Dialect.POSTGRESQL.equals(
+                            connection.unwrap(CloudSpannerJdbcConnection.class).getDialect())));
   }
 }

--- a/samples/spring-data-jdbc/src/test/java/com/google/cloud/spanner/sample/ApplicationTest.java
+++ b/samples/spring-data-jdbc/src/test/java/com/google/cloud/spanner/sample/ApplicationTest.java
@@ -817,7 +817,7 @@ public class ApplicationTest extends AbstractMockServerTest {
     SpringApplication.run(Application.class).close();
 
     assertEquals(
-        44,
+        42,
         mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).stream()
             .filter(request -> !request.getSql().equals("SELECT 1"))
             .count());


### PR DESCRIPTION
Simplify the dialect detection for the Spring Data JDBC sample to use the built-in function for getting the dialect of a Spanner database.