### PR TITLE
chore: remove owlbot check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -36,7 +36,6 @@ branchProtectionRules:
     - "units (11)"
     - "Kokoro - Test: Integration"
     - "cla/google"
-    - OwlBot Post Processor
     - 'Kokoro - Test: Java GraalVM Native Image'
     - 'Kokoro - Test: Java 17 GraalVM Native Image'
     - javadoc


### PR DESCRIPTION
In this PR:
- Remove Owlbot postprocessor as a required check.