### PR TITLE
chore: use default schema from Dialect

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -523,14 +523,7 @@ class JdbcConnection extends AbstractJdbcConnection {
 
   @Nonnull
   String getDefaultSchema() {
-    // TODO: Update to use getDialect()#getDefaultSchema() when available.
-    switch (getDialect()) {
-      case POSTGRESQL:
-        return "public";
-      case GOOGLE_STANDARD_SQL:
-      default:
-        return "";
-    }
+    return getDialect().getDefaultSchema();
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
@@ -738,6 +738,8 @@ public class JdbcConnectionTest {
       // The default schema is the empty string for GoogleSQL databases.
       // The default schema is 'public' for PostgreSQL databases.
       assertEquals(connection.getDefaultSchema(), connection.getSchema());
+      String expectedDefaultSchema = dialect == Dialect.POSTGRESQL ? "public" : "";
+      assertEquals(expectedDefaultSchema, connection.getSchema());
       // This should be allowed.
       connection.setSchema(connection.getDefaultSchema());
       JdbcSqlExceptionImpl exception =


### PR DESCRIPTION
Cleans up a small TODO in the JDBC driver for getting the default schema based on the database dialect.