### PR TITLE
fix: remove connection-id from metrics

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcConnection.java
@@ -114,7 +114,8 @@ class JdbcConnection extends AbstractJdbcConnection {
   }
 
   @VisibleForTesting
-  static Attributes createOpenTelemetryAttributes(DatabaseId databaseId, boolean includeConnectionId) {
+  static Attributes createOpenTelemetryAttributes(
+      DatabaseId databaseId, boolean includeConnectionId) {
     AttributesBuilder attributesBuilder = Attributes.builder();
     // A unique connection ID should only be included for tracing and not for metrics.
     if (includeConnectionId) {


### PR DESCRIPTION
The OpenTelemetry metrics that were gathered by the JDBC driver also included a unique Connection ID for each connection. This creates too many time series.