### PR TITLE
docs: add metrics exporter to sample app

### DIFF
--- a/samples/spring-data-jdbc/pom.xml
+++ b/samples/spring-data-jdbc/pom.xml
@@ -85,6 +85,11 @@
       <artifactId>exporter-trace</artifactId>
       <version>0.33.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>exporter-metrics</artifactId>
+      <version>0.33.0</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.collections</groupId>


### PR DESCRIPTION
Add a metrics exporter to the sample application to show how to export both traces and metrics when using the JDBC driver.
