### PR TITLE
docs: update README to include all supported ConnectionProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ these can also be supplied in a Properties instance that is passed to the
 - oauthToken (string): A valid pre-existing OAuth token to use for authentication for this connection. Setting this property will take precedence over any value set for a credentials file.
 - lenient (boolean): Enable this to force the JDBC driver to ignore unknown properties in the connection URL. Some applications automatically add additional properties to the URL that are not recognized by the JDBC driver. Normally, the JDBC driver will reject this, unless `lenient` mode is enabled.
 
+For a full list of supported connection properties see https://github.com/googleapis/java-spanner/blob/main/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java.
+
 ### Jar with Dependencies
 A single jar with all dependencies can be downloaded from https://repo1.maven.org/maven2/com/google/cloud/google-cloud-spanner-jdbc/latest
 or be built with the command `mvn package` (select the jar that is named `google-cloud-spanner-jdbc-<version>-single-jar-with-dependencies.jar`).


### PR DESCRIPTION
Without this, users may believe that the supported set of connection properties is exhaustive in the README. In addition there could be lead-time between new features being added and the JDBC itself.

It should be noted that the version linked is `main` branch rather than the one actively used by the JDBC driver.

Fixes #1851