### PR TITLE
perf: use direct executor

### DIFF
--- a/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
+++ b/src/main/java/com/google/cloud/spanner/connection/ConnectionOptionsHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.spanner.connection.StatementExecutor.StatementExecutorType;
+
+@InternalApi
+public class ConnectionOptionsHelper {
+
+  @InternalApi
+  public static ConnectionOptions.Builder useDirectExecutorIfNotUseVirtualThreads(
+      String uri, ConnectionOptions.Builder builder) {
+    ConnectionState connectionState = new ConnectionState(ConnectionProperties.parseValues(uri));
+    if (!connectionState.getValue(ConnectionProperties.USE_VIRTUAL_THREADS).getValue()) {
+      return builder.setStatementExecutorType(StatementExecutorType.DIRECT_EXECUTOR);
+    }
+    return builder;
+  }
+
+  @InternalApi
+  public static boolean usesDirectExecutor(ConnectionOptions options) {
+    return options.getStatementExecutorType() == StatementExecutorType.DIRECT_EXECUTOR;
+  }
+
+  private ConnectionOptionsHelper() {}
+}

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
@@ -21,6 +21,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.connection.AbstractStatementParser;
 import com.google.cloud.spanner.connection.ConnectionOptions;
+import com.google.cloud.spanner.connection.ConnectionOptionsHelper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.rpc.Code;
 import java.sql.CallableStatement;
@@ -53,6 +54,7 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
   private final ConnectionOptions options;
   private final com.google.cloud.spanner.connection.Connection spanner;
   private final Properties clientInfo;
+  private final boolean usesDirectExecutor;
   private AbstractStatementParser parser;
 
   private SQLWarning firstWarning = null;
@@ -63,6 +65,7 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
     this.options = options;
     this.spanner = options.getConnection();
     this.clientInfo = new Properties(JdbcDatabaseMetaData.getDefaultClientInfoProperties());
+    this.usesDirectExecutor = ConnectionOptionsHelper.usesDirectExecutor(options);
   }
 
   /** Return the corresponding {@link com.google.cloud.spanner.connection.Connection} */
@@ -81,6 +84,10 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
 
   Spanner getSpanner() {
     return this.spanner.getSpanner();
+  }
+
+  boolean usesDirectExecutor() {
+    return this.usesDirectExecutor;
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcStatement.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcStatement.java
@@ -33,6 +33,8 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -41,6 +43,8 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
   private static final String CURSORS_NOT_SUPPORTED = "Cursors are not supported";
   private static final String ONLY_FETCH_FORWARD_SUPPORTED = "Only fetch_forward is supported";
   final AbstractStatementParser parser;
+  private final Lock executingLock;
+  private volatile Thread executingThread;
   private boolean closed;
   private boolean closeOnCompletion;
   private boolean poolable;
@@ -50,6 +54,11 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
   AbstractJdbcStatement(JdbcConnection connection) throws SQLException {
     this.connection = connection;
     this.parser = connection.getParser();
+    if (connection.usesDirectExecutor()) {
+      this.executingLock = new ReentrantLock();
+    } else {
+      this.executingLock = null;
+    }
   }
 
   @Override
@@ -228,6 +237,10 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
       Supplier<T> runnable, Function<T, Boolean> shouldResetTimeout) throws SQLException {
     StatementTimeout originalTimeout = setTemporaryStatementTimeout();
     T result = null;
+    if (this.executingLock != null) {
+      this.executingLock.lock();
+      this.executingThread = Thread.currentThread();
+    }
     try {
       Stopwatch stopwatch = Stopwatch.createStarted();
       result = runnable.get();
@@ -237,6 +250,10 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
     } catch (SpannerException spannerException) {
       throw JdbcSqlExceptionFactory.of(spannerException);
     } finally {
+      if (this.executingLock != null) {
+        this.executingThread = null;
+        this.executingLock.unlock();
+      }
       if (shouldResetTimeout.apply(result)) {
         resetStatementTimeout(originalTimeout);
       }
@@ -330,7 +347,16 @@ abstract class AbstractJdbcStatement extends AbstractJdbcWrapper implements Stat
   @Override
   public void cancel() throws SQLException {
     checkClosed();
-    connection.getSpannerConnection().cancel();
+    if (this.executingThread != null) {
+      // This is a best-effort operation. It could be that the executing thread is set to null
+      // between the if-check and the actual execution. Just ignore if that happens.
+      try {
+        this.executingThread.interrupt();
+      } catch (NullPointerException ignore) {
+      }
+    } else {
+      connection.getSpannerConnection().cancel();
+    }
   }
 
   @Override

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDriver.java
@@ -23,6 +23,7 @@ import com.google.cloud.spanner.SessionPoolOptionsHelper;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.connection.ConnectionOptions;
 import com.google.cloud.spanner.connection.ConnectionOptions.ConnectionProperty;
+import com.google.cloud.spanner.connection.ConnectionOptionsHelper;
 import com.google.rpc.Code;
 import io.opentelemetry.api.OpenTelemetry;
 import java.sql.Connection;
@@ -244,6 +245,9 @@ public class JdbcDriver implements Driver {
     // Enable multiplexed sessions by default for the JDBC driver.
     builder.setSessionPoolOptions(
         SessionPoolOptionsHelper.useMultiplexedSessions(SessionPoolOptions.newBuilder()).build());
+    // Enable direct executor for JDBC, as we don't use the async API.
+    builder =
+        ConnectionOptionsHelper.useDirectExecutorIfNotUseVirtualThreads(connectionUrl, builder);
     return builder.build();
   }
 


### PR DESCRIPTION
Use a direct executor by default for JDBC connections, as these do not use the async API, and cancelling statements can be handled by directly in the JDBC driver. This reduces the overall number of threads that is created by the JDBC driver.
