### PR TITLE
fix: clear interrupted flag after cancel

### DIFF
--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcStatementTimeoutTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcStatementTimeoutTest.java
@@ -161,7 +161,6 @@ public class JdbcStatementTimeoutTest extends AbstractMockServerTest {
                         message instanceof ExecuteSqlRequest
                             && ((ExecuteSqlRequest) message).getSql().equals(sql),
                     5000L);
-                System.out.println("Cancelling statement");
                 statement.cancel();
                 return null;
               });


### PR DESCRIPTION
Clear the interrupted flag after cancelling a statement when using a direct executor.

Fixes #1879