### PR TITLE
feat: add methods for unwrapping Spanner client

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -108,4 +108,19 @@
     <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
     <method>void setAutoBatchDmlUpdateCountVerification(boolean)</method>
   </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.DatabaseClient getDatabaseClient()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.Spanner getSpanner()</method>
+  </difference>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection</className>
+    <method>com.google.cloud.spanner.DatabaseId getDatabaseId()</method>
+  </difference>
 </differences>

--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcConnection.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.spanner.jdbc;
 
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
@@ -68,6 +70,16 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
     this.usesDirectExecutor = ConnectionOptionsHelper.usesDirectExecutor(options);
   }
 
+  @Override
+  public DatabaseId getDatabaseId() {
+    return this.options.getDatabaseId();
+  }
+
+  @Override
+  public DatabaseClient getDatabaseClient() {
+    return getSpannerConnection().getDatabaseClient();
+  }
+
   /** Return the corresponding {@link com.google.cloud.spanner.connection.Connection} */
   com.google.cloud.spanner.connection.Connection getSpannerConnection() {
     return spanner;
@@ -82,7 +94,8 @@ abstract class AbstractJdbcConnection extends AbstractJdbcWrapper
     return options;
   }
 
-  Spanner getSpanner() {
+  @Override
+  public Spanner getSpanner() {
     return this.spanner.getSpanner();
   }
 

--- a/src/main/java/com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/CloudSpannerJdbcConnection.java
@@ -20,10 +20,13 @@ import com.google.cloud.spanner.AbortedDueToConcurrentModificationException;
 import com.google.cloud.spanner.AbortedException;
 import com.google.cloud.spanner.CommitResponse;
 import com.google.cloud.spanner.CommitStats;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options.QueryOption;
 import com.google.cloud.spanner.PartitionOptions;
+import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.connection.AutocommitDmlMode;
 import com.google.cloud.spanner.connection.SavepointSupport;
@@ -46,6 +49,28 @@ import javax.annotation.Nonnull;
  * CloudSpannerJdbcConnection} instance.
  */
 public interface CloudSpannerJdbcConnection extends Connection {
+
+  /**
+   * Returns the {@link DatabaseId} of the database that this {@link Connection} is connected to.
+   */
+  default DatabaseId getDatabaseId() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the underlying {@link DatabaseClient} that is used by this connection. Operations that
+   * are executed on the {@link DatabaseClient} that is returned has no impact on this {@link
+   * Connection}, e.g. starting a read/write transaction on the {@link DatabaseClient} will not
+   * start a transaction on this connection.
+   */
+  default DatabaseClient getDatabaseClient() {
+    throw new UnsupportedOperationException();
+  }
+
+  /** Returns the underlying {@link Spanner} instance that is used by this connection. */
+  default Spanner getSpanner() {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Sets the transaction tag to use for the current transaction. This method may only be called

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcConnectionTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -98,6 +99,16 @@ public class JdbcConnectionTest {
     ConnectionOptions options = mock(ConnectionOptions.class);
     when(options.getDatabaseId()).thenReturn(DatabaseId.of("project", "instance", "database"));
     return options;
+  }
+
+  @Test
+  public void testGetDatabaseClient() throws SQLException {
+    ConnectionOptions options = mockOptions();
+    try (Connection connection = createConnection(options)) {
+      CloudSpannerJdbcConnection spannerJdbcConnection =
+          connection.unwrap(CloudSpannerJdbcConnection.class);
+      assertNotNull(spannerJdbcConnection.getDatabaseClient());
+    }
   }
 
   @Test


### PR DESCRIPTION
Adds methods for unwrapping the underlying DatabaseClient and Spanner instance that is used by a JDBC connection.