### PR TITLE
feat: support FOR UPDATE clauses

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
@@ -479,7 +479,7 @@ class JdbcDatabaseMetaData extends AbstractJdbcWrapper implements DatabaseMetaDa
 
   @Override
   public boolean supportsSelectForUpdate() {
-    return false;
+    return true;
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
@@ -250,7 +250,7 @@ public class JdbcDatabaseMetaDataTest {
     assertTrue(meta.supportsSchemasInPrivilegeDefinitions());
     assertTrue(meta.supportsSchemasInProcedureCalls());
     assertTrue(meta.supportsSchemasInTableDefinitions());
-    assertFalse(meta.supportsSelectForUpdate());
+    assertTrue(meta.supportsSelectForUpdate());
     assertFalse(meta.supportsStatementPooling());
     assertFalse(meta.supportsStoredFunctionsUsingCallSyntax());
     assertFalse(meta.supportsStoredProcedures());


### PR DESCRIPTION
Spanner now supports FOR UPDATE clauses. This is now also reflected in the DatabaseMetaData returned by the JDBC driver.

See also https://cloud.google.com/spanner/docs/release-notes#January_27_2025
