### PR TITLE
feat: support isolation level repeatable read

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/IsolationLevelConverter.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/IsolationLevelConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.jdbc;
+
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+
+class IsolationLevelConverter {
+  static IsolationLevel convertToSpanner(int jdbcIsolationLevel) throws SQLException {
+    switch (jdbcIsolationLevel) {
+      case Connection.TRANSACTION_SERIALIZABLE:
+        return IsolationLevel.SERIALIZABLE;
+      case Connection.TRANSACTION_REPEATABLE_READ:
+        return IsolationLevel.REPEATABLE_READ;
+      case Connection.TRANSACTION_READ_COMMITTED:
+      case Connection.TRANSACTION_READ_UNCOMMITTED:
+      case Connection.TRANSACTION_NONE:
+        throw new SQLFeatureNotSupportedException(
+            "Unsupported JDBC isolation level: " + jdbcIsolationLevel);
+      default:
+        throw new IllegalArgumentException("Invalid JDBC isolation level: " + jdbcIsolationLevel);
+    }
+  }
+
+  static int convertToJdbc(IsolationLevel isolationLevel) {
+    switch (isolationLevel) {
+        // Translate UNSPECIFIED to SERIALIZABLE as that is the default isolation level.
+      case ISOLATION_LEVEL_UNSPECIFIED:
+      case SERIALIZABLE:
+        return Connection.TRANSACTION_SERIALIZABLE;
+      case REPEATABLE_READ:
+        return Connection.TRANSACTION_REPEATABLE_READ;
+      default:
+        throw new IllegalArgumentException(
+            "Unknown or unsupported isolation level: " + isolationLevel);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaData.java
@@ -664,7 +664,12 @@ class JdbcDatabaseMetaData extends AbstractJdbcWrapper implements DatabaseMetaDa
 
   @Override
   public boolean supportsTransactionIsolationLevel(int level) {
-    return Connection.TRANSACTION_SERIALIZABLE == level;
+    return supportsIsolationLevel(level);
+  }
+
+  static boolean supportsIsolationLevel(int level) {
+    return Connection.TRANSACTION_SERIALIZABLE == level
+        || Connection.TRANSACTION_REPEATABLE_READ == level;
   }
 
   @Override

--- a/src/test/java/com/google/cloud/spanner/jdbc/IsolationLevelConverterTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/IsolationLevelConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.jdbc;
+
+import static com.google.cloud.spanner.jdbc.IsolationLevelConverter.convertToJdbc;
+import static com.google.cloud.spanner.jdbc.IsolationLevelConverter.convertToSpanner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IsolationLevelConverterTest {
+
+  @Test
+  public void testConvertToSpanner() throws SQLException {
+    assertEquals(
+        IsolationLevel.SERIALIZABLE, convertToSpanner(Connection.TRANSACTION_SERIALIZABLE));
+    assertEquals(
+        IsolationLevel.REPEATABLE_READ, convertToSpanner(Connection.TRANSACTION_REPEATABLE_READ));
+
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> convertToSpanner(Connection.TRANSACTION_READ_COMMITTED));
+    assertThrows(
+        SQLFeatureNotSupportedException.class,
+        () -> convertToSpanner(Connection.TRANSACTION_READ_UNCOMMITTED));
+    assertThrows(
+        SQLFeatureNotSupportedException.class, () -> convertToSpanner(Connection.TRANSACTION_NONE));
+
+    assertThrows(IllegalArgumentException.class, () -> convertToSpanner(-1));
+  }
+
+  @Test
+  public void testConvertToJdbc() {
+    // There is no 'unspecified' isolation level in JDBC, so we convert this to the default
+    // SERIALIZABLE isolation level in Spanner.
+    assertEquals(
+        Connection.TRANSACTION_SERIALIZABLE,
+        convertToJdbc(IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED));
+    assertEquals(Connection.TRANSACTION_SERIALIZABLE, convertToJdbc(IsolationLevel.SERIALIZABLE));
+    assertEquals(
+        Connection.TRANSACTION_REPEATABLE_READ, convertToJdbc(IsolationLevel.REPEATABLE_READ));
+
+    assertThrows(IllegalArgumentException.class, () -> convertToJdbc(IsolationLevel.UNRECOGNIZED));
+  }
+}

--- a/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/JdbcDatabaseMetaDataTest.java
@@ -265,12 +265,12 @@ public class JdbcDatabaseMetaDataTest {
     assertFalse(meta.usesLocalFiles());
     assertFalse(meta.usesLocalFilePerTable());
     assertTrue(meta.supportsTransactionIsolationLevel(Connection.TRANSACTION_SERIALIZABLE));
+    assertTrue(meta.supportsTransactionIsolationLevel(Connection.TRANSACTION_REPEATABLE_READ));
     for (int level :
         new int[] {
           Connection.TRANSACTION_NONE,
           Connection.TRANSACTION_READ_COMMITTED,
           Connection.TRANSACTION_READ_UNCOMMITTED,
-          Connection.TRANSACTION_REPEATABLE_READ
         }) {
       assertFalse(meta.supportsTransactionIsolationLevel(level));
     }

--- a/src/test/java/com/google/cloud/spanner/jdbc/TransactionMockServerTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/TransactionMockServerTest.java
@@ -17,10 +17,14 @@
 package com.google.cloud.spanner.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
 import com.google.cloud.spanner.connection.SpannerPool;
 import com.google.spanner.v1.CommitRequest;
+import com.google.spanner.v1.ExecuteSqlRequest;
+import com.google.spanner.v1.TransactionOptions.IsolationLevel;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -45,9 +49,13 @@ public class TransactionMockServerTest extends AbstractMockServerTest {
   }
 
   private String createUrl() {
+    return createUrl("");
+  }
+
+  private String createUrl(String extraOptions) {
     return String.format(
-        "jdbc:cloudspanner://localhost:%d/projects/%s/instances/%s/databases/%s?usePlainText=true;autoCommit=false",
-        getPort(), "proj", "inst", "db");
+        "jdbc:cloudspanner://localhost:%d/projects/%s/instances/%s/databases/%s?usePlainText=true;autoCommit=false%s",
+        getPort(), "proj", "inst", "db", extraOptions);
   }
 
   @Override
@@ -97,5 +105,63 @@ public class TransactionMockServerTest extends AbstractMockServerTest {
     }
 
     assertEquals(0, mockSpanner.countRequestsOfType(CommitRequest.class));
+  }
+
+  @Test
+  public void testUsesDefaultIsolationLevel() throws SQLException {
+    try (Connection connection = createJdbcConnection()) {
+      for (IsolationLevel isolationLevel :
+          new IsolationLevel[] {IsolationLevel.SERIALIZABLE, IsolationLevel.REPEATABLE_READ}) {
+        //noinspection MagicConstant
+        connection.setTransactionIsolation(IsolationLevelConverter.convertToJdbc(isolationLevel));
+        runTestTransaction(connection, isolationLevel);
+      }
+    }
+  }
+
+  @Test
+  public void testUsesManualIsolationLevel() throws SQLException {
+    try (Connection connection = createJdbcConnection()) {
+      connection.setAutoCommit(true);
+      for (IsolationLevel isolationLevel :
+          new IsolationLevel[] {IsolationLevel.SERIALIZABLE, IsolationLevel.REPEATABLE_READ}) {
+        connection
+            .createStatement()
+            .execute(
+                "begin transaction isolation level " + isolationLevel.toString().replace("_", " "));
+        runTestTransaction(connection, isolationLevel);
+      }
+    }
+  }
+
+  @Test
+  public void testUsesDefaultIsolationLevelInConnectionString() throws SQLException {
+    for (IsolationLevel isolationLevel :
+        new IsolationLevel[] {IsolationLevel.SERIALIZABLE, IsolationLevel.REPEATABLE_READ}) {
+      try (Connection connection =
+          DriverManager.getConnection(
+              createUrl(";default_isolation_level=" + isolationLevel.name()))) {
+        runTestTransaction(connection, isolationLevel);
+      }
+    }
+  }
+
+  void runTestTransaction(Connection connection, IsolationLevel expectedIsolationLevel)
+      throws SQLException {
+    String sql = "insert into foo (id) values (1)";
+    mockSpanner.putStatementResult(
+        StatementResult.update(com.google.cloud.spanner.Statement.of(sql), 1L));
+
+    assertEquals(1, connection.createStatement().executeUpdate(sql));
+    connection.commit();
+
+    assertEquals(1, mockSpanner.countRequestsOfType(ExecuteSqlRequest.class));
+    ExecuteSqlRequest request = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class).get(0);
+    assertTrue(request.hasTransaction());
+    assertTrue(request.getTransaction().hasBegin());
+    assertTrue(request.getTransaction().getBegin().hasReadWrite());
+    assertEquals(expectedIsolationLevel, request.getTransaction().getBegin().getIsolationLevel());
+
+    mockSpanner.clearRequests();
   }
 }


### PR DESCRIPTION
Adds support for setting the transaction isolation level to repeatable read.
