### PR TITLE
build: use the default env for integration tests

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -76,8 +76,6 @@ integration)
       -DtrimStackTrace=false \
       -Dclirr.skip=true \
       -Denforcer.skip=true \
-      -Dspanner.testenv.instance=projects/span-cloud-testing/instances/java-client-integration-test \
-      -Dspanner.gce.config.project_id=span-cloud-testing \
       -fae \
       verify
     RETURN_CODE=$?

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -11,13 +11,24 @@ env_vars: {
   value: "integration"
 }
 
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "secret_manager/java-client-testing"
+  value: "secret_manager/java-it-service-account"
 }
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-client-testing"
+  value: "java-it-service-account"
 }
 


### PR DESCRIPTION
Use the default environment for integration tests.

Also adds an explicit check to the test whether there are credentials available to make debugging Unauthenticated errors in integration tests a bit easier.
