### PR TITLE
chore: add ByteBuddy for tests for MyBatis sample

### DIFF
--- a/samples/spring-data-mybatis/googlesql/pom.xml
+++ b/samples/spring-data-mybatis/googlesql/pom.xml
@@ -104,6 +104,19 @@
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
+    <!-- TODO: Remove when the mock server no longer uses this -->
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.17.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+      <version>1.17.7</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Adds the ByteBuddy dependency that is needed for some test workarounds for mTLS.