### PR TITLE
chore: Support text/varchar type in JDBC

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
@@ -297,6 +297,32 @@ enum JdbcDataType {
       return Type.string();
     }
   },
+  TEXT {
+    @Override
+    public int getSqlType() {
+      return Types.NVARCHAR;
+    }
+
+    @Override
+    public Class<String> getJavaClass() {
+      return String.class;
+    }
+
+    @Override
+    public Code getCode() {
+      return Code.STRING;
+    }
+
+    @Override
+    public List<String> getArrayElements(ResultSet rs, int columnIndex) {
+      return rs.getStringList(columnIndex);
+    }
+
+    @Override
+    public Type getSpannerType() {
+      return Type.string();
+    }
+  },
   JSON {
     @Override
     public int getSqlType() {

--- a/src/main/resources/com/google/cloud/spanner/jdbc/postgresql/DatabaseMetaData_GetColumns.sql
+++ b/src/main/resources/com/google/cloud/spanner/jdbc/postgresql/DatabaseMetaData_GetColumns.sql
@@ -28,7 +28,10 @@ SELECT TABLE_CATALOG AS "TABLE_CAT", TABLE_SCHEMA AS "TABLE_SCHEM", TABLE_NAME A
            WHEN DATA_TYPE = 'jsonb' THEN -9
            WHEN DATA_TYPE = 'timestamp with time zone' THEN 93
            END AS "DATA_TYPE",
-       DATA_TYPE AS "TYPE_NAME",
+       CASE
+           WHEN spanner_type LIKE 'character varying[]' then '_varchar'
+           ELSE DATA_TYPE
+           END AS "TYPE_NAME",
        CASE
            WHEN DATA_TYPE LIKE 'ARRAY' THEN 0
            WHEN DATA_TYPE = 'boolean' THEN NULL


### PR DESCRIPTION
1. Using [@ListArrayType](https://github.com/vladmihalcea/hypersistence-utils/blob/885c2d7f4626e6b6e306631c32fb529e62981717/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/array/ListArrayType.java) type for a `character varying[]` is actually converted to Postgres `text` type [Ref](https://github.com/vladmihalcea/hypersistence-utils/blob/885c2d7f4626e6b6e306631c32fb529e62981717/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/ListArrayTypeDescriptor.java#L124).
2. `character varying[]` type is not actually returning the type of elements in array which is `varchar`. We are exposing the type in TYPE_NAME column. Why are we adding `_` to the type name? It's because PostgreSQL names array types by prepending an underscore to the base name.