### PR TITLE
fix: cast double Inf and NaN to float

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapper.java
@@ -291,7 +291,7 @@ abstract class AbstractJdbcWrapper implements Wrapper {
 
   /** Cast value and throw {@link SQLException} if out-of-range. */
   static float checkedCastToFloat(double val) throws SQLException {
-    if (val > Float.MAX_VALUE || val < -Float.MAX_VALUE) {
+    if (Double.isFinite(val) && (val > Float.MAX_VALUE || val < -Float.MAX_VALUE)) {
       throw JdbcSqlExceptionFactory.of(
           String.format(OUT_OF_RANGE_MSG, "float", val), com.google.rpc.Code.OUT_OF_RANGE);
     }

--- a/src/test/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapperTest.java
+++ b/src/test/java/com/google/cloud/spanner/jdbc/AbstractJdbcWrapperTest.java
@@ -256,7 +256,7 @@ public class AbstractJdbcWrapperTest {
   }
 
   @Test
-  public void testCheckedCastToFloat() {
+  public void testCheckedCastToFloat() throws SQLException {
     final CheckedCastChecker<Double> checker =
         new CheckedCastChecker<>(AbstractJdbcWrapper::checkedCastToFloat);
     assertThat(checker.cast(0D)).isTrue();
@@ -268,6 +268,16 @@ public class AbstractJdbcWrapperTest {
     assertThat(checker.cast((double) Float.MIN_VALUE)).isTrue();
     assertThat(checker.cast(-Float.MAX_VALUE * 2d)).isFalse();
     assertThat(checker.cast(-Double.MAX_VALUE)).isFalse();
+
+    assertEquals(
+        Float.POSITIVE_INFINITY,
+        AbstractJdbcWrapper.checkedCastToFloat(Double.POSITIVE_INFINITY),
+        0.0d);
+    assertEquals(
+        Float.NEGATIVE_INFINITY,
+        AbstractJdbcWrapper.checkedCastToFloat(Double.NEGATIVE_INFINITY),
+        0.0d);
+    assertEquals(Float.NaN, AbstractJdbcWrapper.checkedCastToFloat(Double.NaN), 0.0d);
   }
 
   @Test


### PR DESCRIPTION
Casting a FLOAT64 value containing either Inf or NaN to a Java float failed, while Java itself allows the same conversion from a double Inf or NaN to the corresponding float Inf or NaN.

Fixes #2256
