### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,13 +2,7 @@ releaseType: java-yoshi
 bumpMinorPreMajor: true
 handleGHRelease: true
 branches:
-- branch: 1.21.x
-  releaseType: java-yoshi
-  bumpMinorPreMajor: true
-  handleGHRelease: true
-- branch: protobuf-4.x-rc
-  releaseType: java-yoshi
-  bumpMinorPreMajor: true
-  handleGHRelease: true
-  manifest: true
+    - branch: 1.21.x
+    - branch: protobuf-4.x-rc
+      manifest: true
 extraFiles: ["README.md"]


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.