### PR TITLE
deps: override grpc-gcp version to 1.9.0 to fix NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Override grpc-gcp version from shared-dependencies BOM to match google-cloud-spanner requirements -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>grpc-gcp</artifactId>
+        <version>1.9.0</version>
+      </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>
         <artifactId>opencensus-api</artifactId>


### PR DESCRIPTION
The google-cloud-shared-dependencies BOM (via sdk-platform-java-config parent)
manages grpc-gcp to version 1.6.1, which overrides the 1.9.0 version declared
by google-cloud-spanner 6.105.0.

This causes NoSuchMethodError for `setInitSize(int)` method in
GcpChannelPoolOptions.Builder, which was added in grpc-gcp 1.7.0 as part
of the dynamic channel pool scaling feature.

The fix explicitly declares grpc-gcp 1.9.0 in dependencyManagement to
ensure the correct version is used.