### PR TITLE
feat: Support float4 in JDBC

### DIFF
--- a/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
+++ b/src/main/java/com/google/cloud/spanner/jdbc/JdbcDataType.java
@@ -113,6 +113,8 @@ enum JdbcDataType {
     }
   },
   FLOAT32 {
+    private final Set<String> aliases = new HashSet<>(Collections.singletonList("float4"));
+
     @Override
     public int getSqlType() {
       return Types.REAL;
@@ -151,6 +153,11 @@ enum JdbcDataType {
     @Override
     public Type getSpannerType() {
       return Type.float32();
+    }
+
+    @Override
+    public Set<String> getPostgreSQLAliases() {
+      return aliases;
     }
   },
   FLOAT64 {


### PR DESCRIPTION
**Description:**

In PostgreSQL, both `real` and `float4` are synonyms. If customer defines the array column type as float4 or real, it should work with the JDBC.